### PR TITLE
chore: add support to customize ios and android sdk versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,63 @@ const riveRef = useRef<HybridView<RiveViewProps, RiveViewMethods>>(null);
 />
 ```
 
+## Native SDK Version Customization
+
+> **⚠️ Advanced Usage:** Customizing native SDK versions is intended for advanced users only. Using non-default versions may cause build-time errors, or compatibility issues. Always review and update custom versions when upgrading react-native-rive.
+
+By default, react-native-rive uses specific versions of the Rive native SDKs defined in the library's `package.json` (`runtimeVersions.ios` and `runtimeVersions.android`). You can customize these versions if needed.
+
+### Vanilla React Native
+
+Add the appropriate properties to your configuration files:
+
+**iOS** - Add to `ios/Podfile.properties.json`:
+
+```json
+{
+  "RiveRuntimeIOSVersion": "6.13.0"
+}
+```
+
+**Android** - Add to `android/gradle.properties`:
+
+```properties
+Rive_RiveRuntimeAndroidVersion=10.6.0
+```
+
+### Expo
+
+Use an inline config plugin in your `app.config.ts`:
+
+```typescript
+import { withPodfileProperties, withGradleProperties } from '@expo/config-plugins';
+
+export default {
+  expo: {
+    // ... other config
+    plugins: [
+      (config) => {
+        config = withPodfileProperties(config, (config) => {
+          config.modResults['RiveRuntimeIOSVersion'] = '6.13.0';
+          return config;
+        });
+
+        config = withGradleProperties(config, (config) => {
+          config.modResults.push({
+            type: 'property',
+            key: 'Rive_RiveRuntimeAndroidVersion',
+            value: '10.6.0',
+          });
+          return config;
+        });
+
+        return config;
+      },
+    ],
+  },
+};
+```
+
 ## Error Handling
 
 All Rive operations can be wrapped in try/catch blocks for error handling:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -122,10 +122,33 @@ repositories {
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
+def getRiveAndroidVersion() {
+  if (rootProject.ext.has('RiveRuntimeAndroidVersion')) {
+    return rootProject.ext.get('RiveRuntimeAndroidVersion')
+  }
+
+  if (project.hasProperty('Rive_RiveRuntimeAndroidVersion')) {
+    return project.property('Rive_RiveRuntimeAndroidVersion')
+  }
+
+  def packageJson = file("${projectDir}/../package.json")
+  if (packageJson.exists()) {
+    def json = new groovy.json.JsonSlurper().parseText(packageJson.text)
+    if (json.runtimeVersions?.android) {
+      return json.runtimeVersions.android
+    }
+  }
+
+  throw new GradleException("Failed to determine Rive Android SDK version. Please ensure package.json contains 'runtimeVersions.android'")
+}
+
+def riveAndroidVersion = getRiveAndroidVersion()
+println "react-native-rive: Rive Android SDK ${riveAndroidVersion}"
+
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'app.rive:rive-android:10.5.0'
+  implementation "app.rive:rive-android:${riveAndroidVersion}"
   implementation "androidx.startup:startup-runtime:1.2.0"
   implementation project(":react-native-nitro-modules")
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
     "url": "https://github.com/rive-app/rive-nitro-react-native/issues"
   },
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
+  "runtimeVersions": {
+    "ios": "6.12.0",
+    "android": "10.5.0"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },


### PR DESCRIPTION
Adds support for customizing Rive native SDK versions on  iOS and Android.

- default native sdk versions moved to `package.json` (`runtimeVersions.ios` and `runtimeVersions.android`)
- allow users to customize the versions. In `ios/Podfile.properties.json`set `"RiveRuntimeIOSVersion":"6.13.0"` key. In `android/gradle.properties` `Rive_RiveRuntimeAndroidVersion=10.6.0`