### PR TITLE
fix: bytes.toData can only be called from js thread

### DIFF
--- a/ios/HybridRiveFileFactory.swift
+++ b/ios/HybridRiveFileFactory.swift
@@ -149,8 +149,9 @@ final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendabl
       (any HybridRiveFileSpec)
     >
   {
+    let data = bytes.toData(copyIfNeeded: false)
     return try genericFrom(
-      check: { bytes.toData(copyIfNeeded: false) },
+      check: { data },
       prepare: { $0 },
       fileWithCustomAssetLoader: { (data, loader) in
         try RiveFile(data: data, loadCdn: loadCdn, customAssetLoader: loader)


### PR DESCRIPTION
<img width="1152" height="340" alt="image" src="https://github.com/user-attachments/assets/7ff29099-13a9-4d87-a8b8-223884814bac" />
