### PR TITLE
fix(android): remove autobind from view configuration as we handle it automatically

### DIFF
--- a/android/src/main/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rive/RiveReactNativeView.kt
@@ -64,7 +64,6 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
         artboardName = config.artboardName,
         stateMachineName = config.stateMachineName,
         autoplay = config.autoPlay,
-        autoBind = config.bindData is BindData.Auto,
         alignment = config.alignment,
         fit = config.fit
       )


### PR DESCRIPTION
In React Native, we manually manage data binding and do not rely on Android's auto-bind property, which throws an error if the file does not have data binding.

We already have the capability to handle all the correct cases in `applyDataBinding` based on defaults and user-provided settings.

Before this change, the view would propagate an error and we would not handle the correct default behaviour: `DataBindMode.Auto` (default), which should not do any data binding if the file does not have any available. Can manually override by setting `DataBindMode.None` if you don't want any bindings.

We handle all of this from [this PR](https://github.com/rive-app/rive-nitro-react-native/pull/23), but forgot to remove the view prop.

https://github.com/user-attachments/assets/d0ff5dbd-4624-4ffe-8122-2d744f3ec0c3