### PR TITLE
fix(iOS): keep fileRef alive until the customLoaders finished

### DIFF
--- a/ios/HybridRiveFileFactory.swift
+++ b/ios/HybridRiveFileFactory.swift
@@ -36,9 +36,12 @@ final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendabl
 
               let referencedAssetCache = SendableRef(ReferencedAssetCache())
               let factoryCache: SendableRef<RiveFactory?> = .init(nil)
+              let fileRef: SendableRef<RiveFile?> = .init(nil)
               let customLoader = self.assetLoader.createCustomLoader(
                 referencedAssets: referencedAssets, cache: referencedAssetCache,
-                factory: factoryCache)
+                factory: factoryCache,
+                fileRef: fileRef
+              )
 
               let riveFile =
                 if let customLoader = customLoader {
@@ -46,6 +49,7 @@ final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendabl
                 } else {
                   try file(prepared)
                 }
+              fileRef.value = riveFile
 
               let result = (
                 file: riveFile, cache: referencedAssetCache.value, factory: factoryCache.value,

--- a/ios/ReferencedAssetLoader.swift
+++ b/ios/ReferencedAssetLoader.swift
@@ -227,7 +227,8 @@ final class ReferencedAssetLoader {
 
   func createCustomLoader(
     referencedAssets: ReferencedAssetsType?, cache: SendableRef<ReferencedAssetCache>,
-    factory factoryOut: SendableRef<RiveFactory?>
+    factory factoryOut: SendableRef<RiveFactory?>,
+    fileRef: SendableRef<RiveFile?>
   )
     -> LoadAsset?
   {
@@ -244,7 +245,9 @@ final class ReferencedAssetLoader {
       cache.value[asset.uniqueName()] = asset
       factoryOut.value = factory
 
-      self.loadAssetInternal(source: assetData, asset: asset, factory: factory, completion: {})
+      self.loadAssetInternal(source: assetData, asset: asset, factory: factory, completion: {
+        withExtendedLifetime(fileRef) {}
+      })
 
       return true
     }


### PR DESCRIPTION
Fixes: #44 

Make sure RiveFile is alive until all of the customLoaders have finished. Whille not documented RiveFactory lifetime is tied to RiveFile lifetime.