### PR TITLE
fix: only rebind if view model prop is different

### DIFF
--- a/ios/HybridRiveView.swift
+++ b/ios/HybridRiveView.swift
@@ -37,13 +37,41 @@ where Wrapped == HybridDataBindMode {
       return .byName(dataBindByName.byName)
     }
   }
+  
+  /// Check if two HybridDataBindMode values are semantically equal
+  func isEqual(to other: HybridDataBindMode?) -> Bool {
+    guard let lhs = self, let rhs = other else {
+      return self == nil && other == nil
+    }
+    
+    switch (lhs, rhs) {
+    case (.first(let lhsInstance), .first(let rhsInstance)):
+      // Compare ViewModelInstance references
+      let lhsVMI = (lhsInstance as? HybridViewModelInstance)?.viewModelInstance
+      let rhsVMI = (rhsInstance as? HybridViewModelInstance)?.viewModelInstance
+      return lhsVMI === rhsVMI
+      
+    case (.second(let lhsMode), .second(let rhsMode)):
+      // Compare DataBindMode enums
+      return lhsMode == rhsMode
+      
+    case (.third(let lhsByName), .third(let rhsByName)):
+      // Compare byName strings
+      return lhsByName.byName == rhsByName.byName
+      
+    default:
+      return false
+    }
+  }
 }
 
 class HybridRiveView: HybridRiveViewSpec {
   // MARK: View Props
   var dataBind: HybridDataBindMode? = nil {
     didSet {
-      dataBindingChanged = true
+      if !dataBind.isEqual(to: oldValue) {
+        dataBindingChanged = true
+      }
     }
   }
 


### PR DESCRIPTION
Noticed this bug while reviewing: https://github.com/rive-app/rive-nitro-react-native/pull/40

It always set `dataBindingChanged = true` when the `HybridDataBindMode` was of type `name`. Resulting in updating properties not showing if the view is re-rendered resulting in a new named VMI being bound.

TODO: Only observed on iOS, Android worked, but might want to do more investigation.

See [discussion](https://2dimensions.slack.com/archives/C09MY1ACH5M/p1764325411294699).