### PR TITLE
fix: add missing reset() method to iOS RiveReactNativeView

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-turborepo-android-${{ hashFiles('yarn.lock', 'android/**', 'nitrogen/generated/android/**') }}
           restore-keys: |
             ${{ runner.os }}-turborepo-android-
 
@@ -163,7 +163,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.TURBO_CACHE_DIR }}
-          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-turborepo-ios-${{ hashFiles('yarn.lock', 'ios/**', 'nitrogen/generated/ios/**', '*.podspec') }}
           restore-keys: |
             ${{ runner.os }}-turborepo-ios-
 

--- a/ios/RiveReactNativeView.swift
+++ b/ios/RiveReactNativeView.swift
@@ -135,6 +135,11 @@ class RiveReactNativeView: UIView, RiveStateMachineDelegate {
     baseViewModel?.pause()
   }
 
+  @MainActor
+  func reset() {
+    baseViewModel?.reset()
+  }
+
   func refreshAfterAssetChange() {
     if baseViewModel?.isPlaying == false {
       play()


### PR DESCRIPTION
Adds the missing `reset()` method to `RiveReactNativeView.swift` that was missed in #53.

Also fixes CI turbo cache keys to include native files (`ios/**`, `android/**`, `nitrogen/generated/**`). Previously the cache key only used `yarn.lock`, so Swift/Kotlin changes didn't invalidate the build cache.

Fixes #61