### PR TITLE
fix: use dispose() instead of release() with workaround for Nitro issue

### DIFF
--- a/android/src/main/java/com/margelo/nitro/rive/HybridRiveFile.kt
+++ b/android/src/main/java/com/margelo/nitro/rive/HybridRiveFile.kt
@@ -86,8 +86,9 @@ class HybridRiveFile : HybridRiveFileSpec() {
     }
   }
 
-  override fun release() {
+  override fun dispose() {
     scope.cancel()
+    weakViews.clear()
     assetLoader?.dispose()
     assetLoader = null
     riveFile?.release()

--- a/ios/HybridRiveFile.swift
+++ b/ios/HybridRiveFile.swift
@@ -99,12 +99,15 @@ class HybridRiveFile: HybridRiveFileSpec, RiveViewSource {
     }
   }
   
-  func release() throws {
-    //  iOS does not need to release the Rive file.
+  func dispose() {
+    weakViews.removeAll()
+    referencedAssetCache = nil
+    assetLoader = nil
+    cachedFactory = nil
     riveFile = nil
   }
-  
+
   deinit {
-    try? release()
+    dispose()
   }
 }

--- a/nitrogen/generated/android/c++/JHybridRiveFileSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridRiveFileSpec.cpp
@@ -88,10 +88,6 @@ namespace margelo::nitro::rive {
     auto __result = method(_javaPart, artboardBy.has_value() ? JArtboardBy::fromCpp(artboardBy.value()) : nullptr);
     return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelSpec>()) : std::nullopt;
   }
-  void JHybridRiveFileSpec::release() {
-    static const auto method = javaClassStatic()->getMethod<void()>("release");
-    method(_javaPart);
-  }
   void JHybridRiveFileSpec::updateReferencedAssets(const ReferencedAssetsType& referencedAssets) {
     static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("updateReferencedAssets");
     method(_javaPart, JReferencedAssetsType::fromCpp(referencedAssets));

--- a/nitrogen/generated/android/c++/JHybridRiveFileSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridRiveFileSpec.hpp
@@ -57,7 +57,6 @@ namespace margelo::nitro::rive {
     std::optional<std::shared_ptr<HybridViewModelSpec>> viewModelByIndex(double index) override;
     std::optional<std::shared_ptr<HybridViewModelSpec>> viewModelByName(const std::string& name) override;
     std::optional<std::shared_ptr<HybridViewModelSpec>> defaultArtboardViewModel(const std::optional<ArtboardBy>& artboardBy) override;
-    void release() override;
     void updateReferencedAssets(const ReferencedAssetsType& referencedAssets) override;
 
   private:

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveFileSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveFileSpec.kt
@@ -61,10 +61,6 @@ abstract class HybridRiveFileSpec: HybridObject() {
   
   @DoNotStrip
   @Keep
-  abstract fun release(): Unit
-  
-  @DoNotStrip
-  @Keep
   abstract fun updateReferencedAssets(referencedAssets: ReferencedAssetsType): Unit
 
   private external fun initHybrid(): HybridData

--- a/nitrogen/generated/ios/c++/HybridRiveFileSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridRiveFileSpecSwift.hpp
@@ -107,12 +107,6 @@ namespace margelo::nitro::rive {
       auto __value = std::move(__result.value());
       return __value;
     }
-    inline void release() override {
-      auto __result = _swiftPart.release();
-      if (__result.hasError()) [[unlikely]] {
-        std::rethrow_exception(__result.error());
-      }
-    }
     inline void updateReferencedAssets(const ReferencedAssetsType& referencedAssets) override {
       auto __result = _swiftPart.updateReferencedAssets(std::forward<decltype(referencedAssets)>(referencedAssets));
       if (__result.hasError()) [[unlikely]] {

--- a/nitrogen/generated/ios/swift/HybridRiveFileSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridRiveFileSpec.swift
@@ -17,7 +17,6 @@ public protocol HybridRiveFileSpec_protocol: HybridObject {
   func viewModelByIndex(index: Double) throws -> (any HybridViewModelSpec)?
   func viewModelByName(name: String) throws -> (any HybridViewModelSpec)?
   func defaultArtboardViewModel(artboardBy: ArtboardBy?) throws -> (any HybridViewModelSpec)?
-  func release() throws -> Void
   func updateReferencedAssets(referencedAssets: ReferencedAssetsType) throws -> Void
 }
 

--- a/nitrogen/generated/ios/swift/HybridRiveFileSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridRiveFileSpec_cxx.swift
@@ -192,17 +192,6 @@ open class HybridRiveFileSpec_cxx {
   }
   
   @inline(__always)
-  public final func release() -> bridge.Result_void_ {
-    do {
-      try self.__implementation.release()
-      return bridge.create_Result_void_()
-    } catch (let __error) {
-      let __exceptionPtr = __error.toCpp()
-      return bridge.create_Result_void_(__exceptionPtr)
-    }
-  }
-  
-  @inline(__always)
   public final func updateReferencedAssets(referencedAssets: ReferencedAssetsType) -> bridge.Result_void_ {
     do {
       try self.__implementation.updateReferencedAssets(referencedAssets: referencedAssets)

--- a/nitrogen/generated/shared/c++/HybridRiveFileSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridRiveFileSpec.cpp
@@ -18,7 +18,6 @@ namespace margelo::nitro::rive {
       prototype.registerHybridMethod("viewModelByIndex", &HybridRiveFileSpec::viewModelByIndex);
       prototype.registerHybridMethod("viewModelByName", &HybridRiveFileSpec::viewModelByName);
       prototype.registerHybridMethod("defaultArtboardViewModel", &HybridRiveFileSpec::defaultArtboardViewModel);
-      prototype.registerHybridMethod("release", &HybridRiveFileSpec::release);
       prototype.registerHybridMethod("updateReferencedAssets", &HybridRiveFileSpec::updateReferencedAssets);
     });
   }

--- a/nitrogen/generated/shared/c++/HybridRiveFileSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridRiveFileSpec.hpp
@@ -61,7 +61,6 @@ namespace margelo::nitro::rive {
       virtual std::optional<std::shared_ptr<HybridViewModelSpec>> viewModelByIndex(double index) = 0;
       virtual std::optional<std::shared_ptr<HybridViewModelSpec>> viewModelByName(const std::string& name) = 0;
       virtual std::optional<std::shared_ptr<HybridViewModelSpec>> defaultArtboardViewModel(const std::optional<ArtboardBy>& artboardBy) = 0;
-      virtual void release() = 0;
       virtual void updateReferencedAssets(const ReferencedAssetsType& referencedAssets) = 0;
 
     protected:

--- a/src/core/callDispose.ts
+++ b/src/core/callDispose.ts
@@ -1,0 +1,18 @@
+const NITRO_DISPOSE_ERROR = 'failed to define internal native state property';
+
+interface Disposable {
+  dispose(): void;
+}
+
+/** Safely calls dispose(), ignoring errors from https://github.com/mrousavy/nitro/issues/1083 */
+export function callDispose(obj: Disposable): void {
+  try {
+    obj.dispose();
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : String(error ?? '');
+    if (!message.includes(NITRO_DISPOSE_ERROR)) {
+      throw error;
+    }
+  }
+}

--- a/src/hooks/__tests__/useRiveFile.test.ts
+++ b/src/hooks/__tests__/useRiveFile.test.ts
@@ -10,7 +10,7 @@ jest.mock('react-native/Libraries/Image/Image', () => ({
 
 describe('useRiveFile - updateReferencedAssets', () => {
   const mockRiveFile: RiveFile = {
-    release: jest.fn(),
+    dispose: jest.fn(),
     updateReferencedAssets: jest.fn(),
     viewModelCount: 0,
     viewModelByIndex: jest.fn(),

--- a/src/hooks/useRiveFile.ts
+++ b/src/hooks/useRiveFile.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { Image } from 'react-native';
 import { RiveFileFactory } from '../core/RiveFile';
+import { callDispose } from '../core/callDispose';
 import type {
   RiveFile,
   ResolvedReferencedAsset,
@@ -160,7 +161,7 @@ export function useRiveFile(
 
     return () => {
       if (currentFile) {
-        currentFile.release();
+        callDispose(currentFile);
       }
     };
   }, [input]);

--- a/src/specs/RiveFile.nitro.ts
+++ b/src/specs/RiveFile.nitro.ts
@@ -28,8 +28,6 @@ export interface RiveFile
   viewModelByName(name: string): ViewModel | undefined;
   /** Returns the default view model for the provided artboard */
   defaultArtboardViewModel(artboardBy?: ArtboardBy): ViewModel | undefined;
-  /** Release the Rive file. Important to call when done with the file to free resources. */
-  release(): void; // TODO: Switch to `dispose`: https://github.com/mrousavy/nio
   updateReferencedAssets(referencedAssets: ReferencedAssetsType): void;
 }
 


### PR DESCRIPTION
## Summary
- Migrate from `release()` to Nitro's built-in `dispose()`
- Add `callDispose()` utility to handle https://github.com/mrousavy/nitro/issues/1083
