### PR TITLE
chore: add npm publish workflow with OIDC support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
+      - run: yarn install --immutable
+
+      - run: yarn prepare
+
+      - run: npm publish --provenance --access public ${{ github.event.release.prerelease && '--tag next' || ''}}


### PR DESCRIPTION
Adds GitHub workflow to publish to npm on release using OIDC trusted publishing (no token secrets needed).

Requires linking the npm package to this GitHub repo at npmjs.com.