### PR TITLE
ci: ignore copyright year in nitrogen validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Validate Nitrogen Generated Code
         run: |
           yarn nitrogen
-          if ! git diff --exit-code nitrogen/generated/; then
+          if ! git diff --exit-code -I 'Copyright © [0-9]* Marc Rousavy @ Margelo' nitrogen/generated/; then
             echo "Error: nitrogen/generated/ is out of date. Please run 'yarn nitrogen' and commit the changes."
             exit 1
           fi
@@ -79,14 +79,6 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-
-      - name: Validate Nitrogen Generated Code
-        run: |
-          yarn nitrogen
-          if ! git diff --exit-code nitrogen/generated/; then
-            echo "Error: nitrogen/generated/ is out of date. Please run 'yarn nitrogen' and commit the changes."
-            exit 1
-          fi
 
       - name: Build package
         run: yarn prepare


### PR DESCRIPTION
Remove duplicate nitrogen validation from build-library job and add `-I` flag to ignore copyright year line changes in generated files.