### PR TITLE
fix: add missing NitroModules import in HybridViewModelInstance

### DIFF
--- a/ios/HybridViewModelInstance.swift
+++ b/ios/HybridViewModelInstance.swift
@@ -1,3 +1,4 @@
+import NitroModules
 import RiveRuntime
 
 class HybridViewModelInstance: HybridViewModelInstanceSpec {


### PR DESCRIPTION
## Summary
Add missing `import NitroModules` to `HybridViewModelInstance.swift`. This import is required for `RuntimeError` which is used in the `replaceViewModel` method added in #96.

## Root cause
PR #96 was merged with `build-ios` CI failing. The error was:
```
cannot find 'RuntimeError' in scope
```

Consider adding `build-ios` and `build-android` as required status checks for branch protection.