### PR TITLE
fix: add last-release-sha to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "node",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
+  "last-release-sha": "6bc90fc567ad1c9f5930d29224fe406e7be2acaa",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Tell release-please to start tracking from 6bc90fc (the last commit before release-please was added). This fixes the issue where release-please was including all historical commits in the changelog.