### PR TITLE
chore: use PAT for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.PAT_GITHUB }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Use PAT_GITHUB instead of default GITHUB_TOKEN so that release-please PRs and releases trigger CI and publish workflows.