### PR TITLE
feat: useViewModelInstance use name and artboardName when getting vmi from a file

### DIFF
--- a/example/__tests__/hooks.harness.tsx
+++ b/example/__tests__/hooks.harness.tsx
@@ -6,21 +6,36 @@ import {
   waitFor,
   cleanup,
 } from 'react-native-harness';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Text, View } from 'react-native';
-import { RiveFileFactory, useRiveNumber } from '@rive-app/react-native';
+import {
+  RiveFileFactory,
+  useRiveNumber,
+  useViewModelInstance,
+  type RiveFile,
+} from '@rive-app/react-native';
 import type { ViewModelInstance } from '@rive-app/react-native';
 
 const QUICK_START = require('../assets/rive/quick_start.riv');
+const DATABINDING = require('../assets/rive/databinding.riv');
 
-type HookContext = {
+type UseRiveNumberContext = {
   value: number | undefined;
   error: Error | null;
   setValue: ((v: number) => void) | null;
 };
 
-function createHookContext(): HookContext {
+function createUseRiveNumberContext(): UseRiveNumberContext {
   return { value: undefined, error: null, setValue: null };
+}
+
+type UseViewModelInstanceContext = {
+  instance: ViewModelInstance | null;
+  age: number | undefined;
+};
+
+function createUseViewModelInstanceContext(): UseViewModelInstanceContext {
+  return { instance: null, age: undefined };
 }
 
 function UseRiveNumberTestComponent({
@@ -28,7 +43,7 @@ function UseRiveNumberTestComponent({
   context,
 }: {
   instance: ViewModelInstance;
-  context: HookContext;
+  context: UseRiveNumberContext;
 }) {
   const { value, setValue, error } = useRiveNumber('health', instance);
 
@@ -45,6 +60,34 @@ function UseRiveNumberTestComponent({
   );
 }
 
+function UseViewModelInstanceTestComponent({
+  file,
+  context,
+}: {
+  file: RiveFile;
+  context: UseViewModelInstanceContext;
+}) {
+  const instance = useViewModelInstance(file);
+
+  const age = useMemo(() => {
+    if (!instance) return undefined;
+    return instance.numberProperty('age')?.value;
+  }, [instance]);
+
+  useEffect(() => {
+    context.instance = instance;
+    context.age = age;
+  }, [context, instance, age]);
+
+  return (
+    <View>
+      <Text>
+        instance={String(!!instance)} age={String(age)}
+      </Text>
+    </View>
+  );
+}
+
 function expectDefined<T>(value: T): asserts value is NonNullable<T> {
   expect(value).toBeDefined();
 }
@@ -57,7 +100,7 @@ describe('useRiveNumber Hook', () => {
     const instance = vm.createDefaultInstance();
     expectDefined(instance);
 
-    const context = createHookContext();
+    const context = createUseRiveNumberContext();
     await render(
       <UseRiveNumberTestComponent instance={instance} context={context} />
     );
@@ -80,7 +123,7 @@ describe('useRiveNumber Hook', () => {
     const instance = vm.createDefaultInstance();
     expectDefined(instance);
 
-    const context = createHookContext();
+    const context = createUseRiveNumberContext();
     await render(
       <UseRiveNumberTestComponent instance={instance} context={context} />
     );
@@ -97,6 +140,28 @@ describe('useRiveNumber Hook', () => {
     const property = instance.numberProperty('health');
     expectDefined(property);
     expect(property.value).toBe(42);
+
+    cleanup();
+  });
+});
+
+describe('useViewModelInstance hook', () => {
+  it('gets default ViewModel instance from RiveFile', async () => {
+    const file = await RiveFileFactory.fromSource(DATABINDING, undefined);
+    const context = createUseViewModelInstanceContext();
+
+    await render(
+      <UseViewModelInstanceTestComponent file={file} context={context} />
+    );
+
+    await waitFor(
+      () => {
+        expect(context.instance).not.toBeNull();
+      },
+      { timeout: 5000 }
+    );
+
+    expect(context.age).toBe(30);
 
     cleanup();
   });

--- a/src/hooks/__tests__/useViewModelInstance.test.ts
+++ b/src/hooks/__tests__/useViewModelInstance.test.ts
@@ -1,0 +1,269 @@
+import { renderHook } from '@testing-library/react-native';
+import { useViewModelInstance } from '../useViewModelInstance';
+import type { RiveFile } from '../../specs/RiveFile.nitro';
+import type { ViewModel, ViewModelInstance } from '../../specs/ViewModel.nitro';
+import type { ArtboardBy } from '../../specs/ArtboardBy';
+
+function createMockViewModelInstance(): ViewModelInstance {
+  return {
+    instanceName: 'TestInstance',
+    dispose: jest.fn(),
+    numberProperty: jest.fn(),
+    stringProperty: jest.fn(),
+    booleanProperty: jest.fn(),
+    colorProperty: jest.fn(),
+    enumProperty: jest.fn(),
+    triggerProperty: jest.fn(),
+    imageProperty: jest.fn(),
+    listProperty: jest.fn(),
+    artboardProperty: jest.fn(),
+    viewModel: jest.fn(),
+    replaceViewModel: jest.fn(),
+  } as any;
+}
+
+function createMockViewModel(options?: {
+  defaultInstance?: ViewModelInstance;
+  namedInstances?: Record<string, ViewModelInstance>;
+}): ViewModel {
+  return {
+    propertyCount: 0,
+    instanceCount: 1,
+    modelName: 'TestViewModel',
+    dispose: jest.fn(),
+    createInstanceByIndex: jest.fn(),
+    createInstanceByName: jest.fn(
+      (name: string) => options?.namedInstances?.[name]
+    ),
+    createDefaultInstance: jest.fn(() => options?.defaultInstance),
+    createInstance: jest.fn(),
+  } as any;
+}
+
+function createMockRiveFile(options?: {
+  defaultViewModel?: ViewModel;
+  artboardViewModels?: Record<string, ViewModel>;
+}): RiveFile {
+  return {
+    dispose: jest.fn(),
+    updateReferencedAssets: jest.fn(),
+    viewModelCount: 0,
+    artboardCount: 0,
+    artboardNames: [],
+    viewModelByIndex: jest.fn(),
+    viewModelByName: jest.fn(),
+    defaultArtboardViewModel: jest.fn((artboardBy?: ArtboardBy) => {
+      if (artboardBy?.name && options?.artboardViewModels) {
+        return options.artboardViewModels[artboardBy.name];
+      }
+      return options?.defaultViewModel;
+    }),
+    getBindableArtboard: jest.fn(),
+  } as any;
+}
+
+describe('useViewModelInstance - RiveFile with name parameter', () => {
+  it('should use createInstanceByName when name is provided with RiveFile', () => {
+    const personInstance = createMockViewModelInstance();
+    const defaultViewModel = createMockViewModel({
+      namedInstances: { PersonInstance: personInstance },
+    });
+
+    const mockRiveFile = createMockRiveFile({ defaultViewModel });
+
+    const { result } = renderHook(() =>
+      useViewModelInstance(mockRiveFile, { name: 'PersonInstance' })
+    );
+
+    expect(mockRiveFile.defaultArtboardViewModel).toHaveBeenCalledWith(
+      undefined
+    );
+    expect(defaultViewModel.createInstanceByName).toHaveBeenCalledWith(
+      'PersonInstance'
+    );
+    expect(defaultViewModel.createDefaultInstance).not.toHaveBeenCalled();
+    expect(result.current).toBe(personInstance);
+  });
+
+  it('should use defaultArtboardViewModel and createDefaultInstance when no name provided', () => {
+    const defaultInstance = createMockViewModelInstance();
+    const defaultViewModel = createMockViewModel({ defaultInstance });
+
+    const mockRiveFile = createMockRiveFile({ defaultViewModel });
+
+    const { result } = renderHook(() => useViewModelInstance(mockRiveFile));
+
+    expect(mockRiveFile.defaultArtboardViewModel).toHaveBeenCalledWith(
+      undefined
+    );
+    expect(defaultViewModel.createDefaultInstance).toHaveBeenCalled();
+    expect(defaultViewModel.createInstanceByName).not.toHaveBeenCalled();
+    expect(result.current).toBe(defaultInstance);
+  });
+
+  it('should return null when instance name not found and required is false', () => {
+    const defaultViewModel = createMockViewModel({
+      namedInstances: {},
+    });
+
+    const mockRiveFile = createMockRiveFile({ defaultViewModel });
+
+    const { result } = renderHook(() =>
+      useViewModelInstance(mockRiveFile, { name: 'NonExistent' })
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should throw when instance name not found and required is true', () => {
+    const defaultViewModel = createMockViewModel({
+      namedInstances: {},
+    });
+
+    const mockRiveFile = createMockRiveFile({ defaultViewModel });
+
+    expect(() =>
+      renderHook(() =>
+        useViewModelInstance(mockRiveFile, {
+          name: 'NonExistent',
+          required: true,
+        })
+      )
+    ).toThrow("ViewModel instance 'NonExistent' not found");
+  });
+
+  it('should return null when artboardName not found and required is false', () => {
+    const mockRiveFile = createMockRiveFile({
+      artboardViewModels: {},
+    });
+
+    const { result } = renderHook(() =>
+      useViewModelInstance(mockRiveFile, { artboardName: 'MissingArtboard' })
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it('should throw when artboardName not found and required is true', () => {
+    const mockRiveFile = createMockRiveFile({
+      artboardViewModels: {},
+    });
+
+    expect(() =>
+      renderHook(() =>
+        useViewModelInstance(mockRiveFile, {
+          artboardName: 'MissingArtboard',
+          required: true,
+        })
+      )
+    ).toThrow("Artboard 'MissingArtboard' not found or has no ViewModel");
+  });
+
+  it('should call onInit when instance is created with name parameter', () => {
+    const personInstance = createMockViewModelInstance();
+    const defaultViewModel = createMockViewModel({
+      namedInstances: { PersonInstance: personInstance },
+    });
+    const onInit = jest.fn();
+
+    const mockRiveFile = createMockRiveFile({ defaultViewModel });
+
+    renderHook(() =>
+      useViewModelInstance(mockRiveFile, { name: 'PersonInstance', onInit })
+    );
+
+    expect(onInit).toHaveBeenCalledWith(personInstance);
+  });
+});
+
+describe('useViewModelInstance - RiveFile with artboardName parameter', () => {
+  it('should use artboardName to get ViewModel from specific artboard', () => {
+    const mainInstance = createMockViewModelInstance();
+    const mainArtboardViewModel = createMockViewModel({
+      defaultInstance: mainInstance,
+    });
+
+    const mockRiveFile = createMockRiveFile({
+      artboardViewModels: { MainArtboard: mainArtboardViewModel },
+    });
+
+    const { result } = renderHook(() =>
+      useViewModelInstance(mockRiveFile, { artboardName: 'MainArtboard' })
+    );
+
+    expect(mockRiveFile.defaultArtboardViewModel).toHaveBeenCalledWith({
+      type: 'name',
+      name: 'MainArtboard',
+    });
+    expect(mainArtboardViewModel.createDefaultInstance).toHaveBeenCalled();
+    expect(result.current).toBe(mainInstance);
+  });
+
+  it('should combine artboardName and name to get specific instance from specific artboard', () => {
+    const specificInstance = createMockViewModelInstance();
+    const mainArtboardViewModel = createMockViewModel({
+      namedInstances: { SpecificInstance: specificInstance },
+    });
+
+    const mockRiveFile = createMockRiveFile({
+      artboardViewModels: { MainArtboard: mainArtboardViewModel },
+    });
+
+    const { result } = renderHook(() =>
+      useViewModelInstance(mockRiveFile, {
+        artboardName: 'MainArtboard',
+        name: 'SpecificInstance',
+      })
+    );
+
+    expect(mockRiveFile.defaultArtboardViewModel).toHaveBeenCalledWith({
+      type: 'name',
+      name: 'MainArtboard',
+    });
+    expect(mainArtboardViewModel.createInstanceByName).toHaveBeenCalledWith(
+      'SpecificInstance'
+    );
+    expect(result.current).toBe(specificInstance);
+  });
+});
+
+describe('useViewModelInstance - ViewModel source', () => {
+  it('should use createInstanceByName when name is provided with ViewModel', () => {
+    const namedInstance = createMockViewModelInstance();
+    const mockViewModel = createMockViewModel({
+      namedInstances: { Gordon: namedInstance },
+    });
+
+    const { result } = renderHook(() =>
+      useViewModelInstance(mockViewModel, { name: 'Gordon' })
+    );
+
+    expect(mockViewModel.createInstanceByName).toHaveBeenCalledWith('Gordon');
+    expect(mockViewModel.createDefaultInstance).not.toHaveBeenCalled();
+    expect(result.current).toBe(namedInstance);
+  });
+
+  it('should use createInstance when useNew is true', () => {
+    const newInstance = createMockViewModelInstance();
+    const mockViewModel = createMockViewModel();
+    (mockViewModel.createInstance as jest.Mock).mockReturnValue(newInstance);
+
+    const { result } = renderHook(() =>
+      useViewModelInstance(mockViewModel, { useNew: true })
+    );
+
+    expect(mockViewModel.createInstance).toHaveBeenCalled();
+    expect(mockViewModel.createDefaultInstance).not.toHaveBeenCalled();
+    expect(result.current).toBe(newInstance);
+  });
+
+  it('should use createDefaultInstance when no params provided', () => {
+    const defaultInstance = createMockViewModelInstance();
+    const mockViewModel = createMockViewModel({ defaultInstance });
+
+    const { result } = renderHook(() => useViewModelInstance(mockViewModel));
+
+    expect(mockViewModel.createDefaultInstance).toHaveBeenCalled();
+    expect(result.current).toBe(defaultInstance);
+  });
+});

--- a/src/hooks/useViewModelInstance.ts
+++ b/src/hooks/useViewModelInstance.ts
@@ -3,16 +3,9 @@ import type { ViewModel, ViewModelInstance } from '../specs/ViewModel.nitro';
 import type { RiveFile } from '../specs/RiveFile.nitro';
 import type { RiveViewRef } from '../index';
 import { callDispose } from '../core/callDispose';
+import { ArtboardByName } from '../specs/ArtboardBy';
 
-export interface UseViewModelInstanceParams {
-  /**
-   * Get a specifically named instance from the ViewModel.
-   */
-  name?: string;
-  /**
-   * Create a new (blank) instance from the ViewModel.
-   */
-  useNew?: boolean;
+interface UseViewModelInstanceBaseParams {
   /**
    * If true, throws an error when the instance cannot be obtained.
    * This is useful with Error Boundaries and ensures TypeScript knows
@@ -27,27 +20,57 @@ export interface UseViewModelInstanceParams {
   onInit?: (instance: ViewModelInstance) => void;
 }
 
+export interface UseViewModelInstanceFileParams
+  extends UseViewModelInstanceBaseParams {
+  /**
+   * The name of the artboard to get the ViewModel from.
+   * If not provided, uses the default artboard.
+   */
+  artboardName?: string;
+  /**
+   * The ViewModel instance name (uses `createInstanceByName()`).
+   * If not provided, creates the default instance.
+   */
+  name?: string;
+}
+
+export interface UseViewModelInstanceViewModelParams
+  extends UseViewModelInstanceBaseParams {
+  /**
+   * The ViewModel instance name (uses `createInstanceByName()`).
+   * If not provided, creates the default instance.
+   */
+  name?: string;
+  /**
+   * Create a new (blank) instance from the ViewModel.
+   */
+  useNew?: boolean;
+}
+
+export type UseViewModelInstanceRefParams = UseViewModelInstanceBaseParams;
+
 type ViewModelSource = ViewModel | RiveFile | RiveViewRef;
 
 function isRiveViewRef(source: ViewModelSource | null): source is RiveViewRef {
-  return (
-    source !== null && source !== undefined && 'getViewModelInstance' in source
-  );
+  return source !== null && 'getViewModelInstance' in source;
 }
 
 function isRiveFile(source: ViewModelSource | null): source is RiveFile {
-  return (
-    source !== null &&
-    source !== undefined &&
-    'defaultArtboardViewModel' in source
-  );
+  return source !== null && 'defaultArtboardViewModel' in source;
 }
+
+type CreateInstanceResult = {
+  instance: ViewModelInstance | null;
+  needsDispose: boolean;
+  error?: string;
+};
 
 function createInstance(
   source: ViewModelSource | null,
   name: string | undefined,
+  artboardName: string | undefined,
   useNew: boolean
-): { instance: ViewModelInstance | null; needsDispose: boolean } {
+): CreateInstanceResult {
   if (!source) {
     return { instance: null, needsDispose: false };
   }
@@ -58,8 +81,29 @@ function createInstance(
   }
 
   if (isRiveFile(source)) {
-    const viewModel = source.defaultArtboardViewModel();
-    const vmi = viewModel?.createDefaultInstance();
+    const viewModel = source.defaultArtboardViewModel(
+      artboardName ? ArtboardByName(artboardName) : undefined
+    );
+    if (!viewModel) {
+      if (artboardName) {
+        return {
+          instance: null,
+          needsDispose: false,
+          error: `Artboard '${artboardName}' not found or has no ViewModel`,
+        };
+      }
+      return { instance: null, needsDispose: false };
+    }
+    const vmi = name
+      ? viewModel.createInstanceByName(name)
+      : viewModel.createDefaultInstance();
+    if (!vmi && name) {
+      return {
+        instance: null,
+        needsDispose: false,
+        error: `ViewModel instance '${name}' not found`,
+      };
+    }
     return { instance: vmi ?? null, needsDispose: true };
   }
 
@@ -67,6 +111,13 @@ function createInstance(
   let vmi: ViewModelInstance | undefined;
   if (name) {
     vmi = source.createInstanceByName(name);
+    if (!vmi) {
+      return {
+        instance: null,
+        needsDispose: false,
+        error: `ViewModel instance '${name}' not found`,
+      };
+    }
   } else if (useNew) {
     vmi = source.createInstance();
   } else {
@@ -79,7 +130,7 @@ function createInstance(
  * Hook for getting a ViewModelInstance from a RiveFile, ViewModel, or RiveViewRef.
  *
  * @param source - The RiveFile, ViewModel, or RiveViewRef to get an instance from
- * @param params - Configuration for which instance to retrieve (only used with ViewModel)
+ * @param params - Configuration for which instance to retrieve
  * @returns The ViewModelInstance or null if not found
  *
  * @example
@@ -87,6 +138,20 @@ function createInstance(
  * // From RiveFile (get default instance)
  * const { riveFile } = useRiveFile(require('./animation.riv'));
  * const instance = useViewModelInstance(riveFile);
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // From RiveFile with specific instance name
+ * const { riveFile } = useRiveFile(require('./animation.riv'));
+ * const instance = useViewModelInstance(riveFile, { name: 'PersonInstance' });
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // From RiveFile with specific artboard
+ * const { riveFile } = useRiveFile(require('./animation.riv'));
+ * const instance = useViewModelInstance(riveFile, { artboardName: 'MainArtboard' });
  * ```
  *
  * @example
@@ -129,20 +194,50 @@ function createInstance(
  * // Values are already set here
  * ```
  */
+// RiveFile overloads
 export function useViewModelInstance(
-  source: ViewModelSource,
-  params: UseViewModelInstanceParams & { required: true }
+  source: RiveFile,
+  params: UseViewModelInstanceFileParams & { required: true }
 ): ViewModelInstance;
 export function useViewModelInstance(
-  source: ViewModelSource | null,
-  params?: UseViewModelInstanceParams
+  source: RiveFile | null,
+  params?: UseViewModelInstanceFileParams
 ): ViewModelInstance | null;
+
+// ViewModel overloads
+export function useViewModelInstance(
+  source: ViewModel,
+  params: UseViewModelInstanceViewModelParams & { required: true }
+): ViewModelInstance;
+export function useViewModelInstance(
+  source: ViewModel | null,
+  params?: UseViewModelInstanceViewModelParams
+): ViewModelInstance | null;
+
+// RiveViewRef overloads
+export function useViewModelInstance(
+  source: RiveViewRef,
+  params: UseViewModelInstanceRefParams & { required: true }
+): ViewModelInstance;
+export function useViewModelInstance(
+  source: RiveViewRef | null,
+  params?: UseViewModelInstanceRefParams
+): ViewModelInstance | null;
+
+// Implementation
 export function useViewModelInstance(
   source: ViewModelSource | null,
-  params?: UseViewModelInstanceParams
+  params?:
+    | UseViewModelInstanceFileParams
+    | UseViewModelInstanceViewModelParams
+    | UseViewModelInstanceRefParams
 ): ViewModelInstance | null {
-  const name = params?.name;
-  const useNew = params?.useNew ?? false;
+  const name = (params as UseViewModelInstanceFileParams | undefined)?.name;
+  const artboardName = (params as UseViewModelInstanceFileParams | undefined)
+    ?.artboardName;
+  const useNew =
+    (params as UseViewModelInstanceViewModelParams | undefined)?.useNew ??
+    false;
   const required = params?.required ?? false;
   const onInit = params?.onInit;
 
@@ -152,13 +247,13 @@ export function useViewModelInstance(
   } | null>(null);
 
   const result = useMemo(() => {
-    const created = createInstance(source, name, useNew);
+    const created = createInstance(source, name, artboardName, useNew);
     if (created.instance && onInit) {
       onInit(created.instance);
     }
     return created;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- onInit excluded intentionally
-  }, [source, name, useNew]);
+  }, [source, name, artboardName, useNew]);
 
   // Dispose previous instance if it changed and needed disposal
   if (
@@ -186,8 +281,10 @@ export function useViewModelInstance(
 
   if (required && result.instance === null) {
     throw new Error(
-      'useViewModelInstance: Failed to get ViewModelInstance. ' +
-        'Ensure the source has a valid ViewModel and instance available.'
+      result.error
+        ? `useViewModelInstance: ${result.error}`
+        : 'useViewModelInstance: Failed to get ViewModelInstance. ' +
+          'Ensure the source has a valid ViewModel and instance available.'
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #124 - `useViewModelInstance` hook now correctly handles the `name` parameter:

- `name` consistently means **ViewModel instance name** (not ViewModel class name) for both `RiveFile` and `ViewModel` sources
- New `artboardName` param for `RiveFile` source to specify which artboard's ViewModel to use
- TypeScript overloads enforce param availability by source type (e.g., `artboardName` only available for `RiveFile`)

## Test plan

- [x] Unit tests pass (`yarn test`)
- [x] TypeScript compiles (`yarn typecheck`)
- [x] Lint passes (`yarn lint`)
- [ ] Harness tests on device