### PR TITLE
feat: add viewModelName param to useViewModelInstance

### DIFF
--- a/src/hooks/__tests__/useViewModelInstance.test.ts
+++ b/src/hooks/__tests__/useViewModelInstance.test.ts
@@ -307,14 +307,14 @@ describe('useViewModelInstance - RiveFile with viewModelName parameter', () => {
 });
 
 describe('useViewModelInstance - ViewModel source', () => {
-  it('should use createInstanceByName when instanceName is provided with ViewModel', () => {
+  it('should use createInstanceByName when name is provided with ViewModel', () => {
     const namedInstance = createMockViewModelInstance();
     const mockViewModel = createMockViewModel({
       namedInstances: { Gordon: namedInstance },
     });
 
     const { result } = renderHook(() =>
-      useViewModelInstance(mockViewModel, { instanceName: 'Gordon' })
+      useViewModelInstance(mockViewModel, { name: 'Gordon' })
     );
 
     expect(mockViewModel.createInstanceByName).toHaveBeenCalledWith('Gordon');

--- a/src/hooks/useViewModelInstance.ts
+++ b/src/hooks/useViewModelInstance.ts
@@ -75,7 +75,7 @@ export interface UseViewModelInstanceViewModelParams
    * The ViewModel instance name (uses `createInstanceByName()`).
    * If not provided, creates the default instance.
    */
-  instanceName?: string;
+  name?: string;
   /**
    * Create a new (blank) instance from the ViewModel.
    */
@@ -287,8 +287,10 @@ export function useViewModelInstance(
     | UseViewModelInstanceViewModelParams
     | UseViewModelInstanceRefParams
 ): ViewModelInstance | null {
-  const instanceName = (params as { instanceName?: string } | undefined)
+  const fileInstanceName = (params as { instanceName?: string } | undefined)
     ?.instanceName;
+  const viewModelInstanceName = (params as { name?: string } | undefined)?.name;
+  const instanceName = fileInstanceName ?? viewModelInstanceName;
   const artboardName = (params as UseViewModelInstanceFileParams | undefined)
     ?.artboardName;
   const viewModelName = (params as UseViewModelInstanceFileParams | undefined)


### PR DESCRIPTION
## Summary
- `artboardName` and `viewModelName` are now mutually exclusive (TypeScript discriminated unions)
- Clarified docs: "ViewModel assigned to artboard" instead of implying ownership

## API

```tsx
// RiveFile source - pick ONE of: default, artboardName, or viewModelName
useViewModelInstance(riveFile, {
  instanceName?: string       // which instance (default if omitted)
})
// OR
useViewModelInstance(riveFile, {
  artboardName: string,       // get ViewModel assigned to this artboard
  instanceName?: string
})
// OR
useViewModelInstance(riveFile, {
  viewModelName: string,      // get ViewModel by name (file-wide)
  instanceName?: string
})

// ViewModel source (unchanged)
useViewModelInstance(viewModel, {
  name?: string,
  useNew?: boolean
})
```