### PR TITLE
chore: add React Compiler to library build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,6 +3,7 @@ module.exports = {
     {
       exclude: /\/node_modules\//,
       presets: ['module:react-native-builder-bob/babel-preset'],
+      plugins: ['babel-plugin-react-compiler'],
     },
     {
       include: /\/node_modules\//,

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/react": "^19.0.0",
     "@typescript-eslint/eslint-plugin": "^8.46.4",
     "@typescript-eslint/parser": "^8.46.4",
+    "babel-plugin-react-compiler": "^1.0.0",
     "commitlint": "^19.6.1",
     "del-cli": "^5.1.0",
     "eslint": "^9.22.0",
@@ -167,7 +168,8 @@
       [
         "module",
         {
-          "esm": true
+          "esm": true,
+          "configFile": true
         }
       ],
       [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4461,6 +4461,7 @@ __metadata:
     "@types/react": ^19.0.0
     "@typescript-eslint/eslint-plugin": ^8.46.4
     "@typescript-eslint/parser": ^8.46.4
+    babel-plugin-react-compiler: ^1.0.0
     commitlint: ^19.6.1
     del-cli: ^5.1.0
     eslint: ^9.22.0


### PR DESCRIPTION
Adds `babel-plugin-react-compiler` to the library's babel config so bob pre-compiles the `lib/module/` output with React Compiler. This auto-memoizes all hooks in the published package, preventing referential instability issues for consumers who don't use React Compiler themselves.

The `configFile: true` option tells bob to use the root `babel.config.js` (which includes both bob's preset and the compiler plugin) instead of bob's internal preset alone.

Metro resolves to `lib/module/` for all external consumers (via the `default` condition in `exports`). The `source` condition is only used in our monorepo example apps where bob's metro config injects it.