### PR TITLE
chore: log test failures to console and add fromURL error test

### DIFF
--- a/example/__tests__/rive.harness.ts
+++ b/example/__tests__/rive.harness.ts
@@ -19,6 +19,20 @@ describe('RiveFile Loading', () => {
     expect(file).toBeDefined();
     expect(file.artboardNames.length).toBeGreaterThan(0);
   });
+
+  it('fromURL with invalid URL throws descriptive error', async () => {
+    try {
+      await RiveFileFactory.fromURL(
+        'https://cdn.rive.app/nonexistent/invalid.riv',
+        undefined
+      );
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e).toBeDefined();
+      const msg = e instanceof Error ? e.message : String(e);
+      expect(msg.length).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe('ViewModel', () => {

--- a/example/src/tests/TestsPage.tsx
+++ b/example/src/tests/TestsPage.tsx
@@ -148,6 +148,7 @@ export default function TestsPage() {
       setTestStates((prev) => new Map(prev).set(key, { status: 'passed' }));
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : String(e);
+      console.error(`[TEST FAIL] ${suiteName} > ${test.name}:`, errorMessage, e);
       cleanupRenderedElement();
       setTestStates((prev) =>
         new Map(prev).set(key, {


### PR DESCRIPTION
Log test failures to console.error so they're visible in React Native devtools. Also adds a test for fromURL with invalid URL to verify error messages are descriptive.