### PR TITLE
fix(android): update nitrogen-generated code to CxxPart/JavaPart pattern

### DIFF
--- a/android/src/main/cpp/cpp-adapter.cpp
+++ b/android/src/main/cpp/cpp-adapter.cpp
@@ -1,6 +1,7 @@
-#include <jni.h>
 #include "riveOnLoad.hpp"
+#include <fbjni/fbjni.h>
+#include <jni.h>
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
-  return margelo::nitro::rive::initialize(vm);
+  return facebook::jni::initialize(vm, []() { margelo::nitro::rive::registerAllNatives(); });
 }

--- a/nitrogen/generated/android/c++/JHybridBindableArtboardSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridBindableArtboardSpec.cpp
@@ -13,42 +13,36 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridBindableArtboardSpec::jhybriddata> JHybridBindableArtboardSpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridBindableArtboardSpec> JHybridBindableArtboardSpec::JavaPart::getJHybridBindableArtboardSpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridBindableArtboardSpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridBindableArtboardSpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridBindableArtboardSpec::CxxPart::jhybriddata> JHybridBindableArtboardSpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridBindableArtboardSpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridBindableArtboardSpec::initHybrid),
-    });
-  }
-
-  size_t JHybridBindableArtboardSpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridBindableArtboardSpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridBindableArtboardSpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridBindableArtboardSpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridBindableArtboardSpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridBindableArtboardSpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridBindableArtboardSpec>(castJavaPart);
   }
 
-  void JHybridBindableArtboardSpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridBindableArtboardSpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridBindableArtboardSpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridBindableArtboardSpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   std::string JHybridBindableArtboardSpec::getArtboardName() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getArtboardName");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getArtboardName");
     auto __result = method(_javaPart);
     return __result->toStdString();
   }

--- a/nitrogen/generated/android/c++/JHybridBindableArtboardSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridBindableArtboardSpec.hpp
@@ -18,34 +18,33 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridBindableArtboardSpec: public jni::HybridClass<JHybridBindableArtboardSpec, JHybridObject>,
-                                     public virtual HybridBindableArtboardSpec {
+  class JHybridBindableArtboardSpec: public virtual HybridBindableArtboardSpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridBindableArtboardSpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridBindableArtboardSpec;";
+      std::shared_ptr<JHybridBindableArtboardSpec> getJHybridBindableArtboardSpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridBindableArtboardSpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridBindableArtboardSpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridBindableArtboardSpec(const jni::local_ref<JHybridBindableArtboardSpec::JavaPart>& javaPart):
       HybridObject(HybridBindableArtboardSpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridBindableArtboardSpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridBindableArtboardSpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridBindableArtboardSpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -58,9 +57,7 @@ namespace margelo::nitro::rive {
     
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridBindableArtboardSpec::javaobject> _javaPart;
+    jni::global_ref<JHybridBindableArtboardSpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridRiveFileFactorySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridRiveFileFactorySpec.cpp
@@ -35,51 +35,45 @@ namespace margelo::nitro::rive { class HybridRiveImageSpec; }
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridRiveFileFactorySpec::jhybriddata> JHybridRiveFileFactorySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridRiveFileFactorySpec> JHybridRiveFileFactorySpec::JavaPart::getJHybridRiveFileFactorySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridRiveFileFactorySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridRiveFileFactorySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridRiveFileFactorySpec::CxxPart::jhybriddata> JHybridRiveFileFactorySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridRiveFileFactorySpec::registerNatives() {
+  std::shared_ptr<JHybridObject> JHybridRiveFileFactorySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridRiveFileFactorySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridRiveFileFactorySpec::JavaPart!");
+    }
+    return std::make_shared<JHybridRiveFileFactorySpec>(castJavaPart);
+  }
+
+  void JHybridRiveFileFactorySpec::CxxPart::registerNatives() {
     registerHybrid({
-      makeNativeMethod("initHybrid", JHybridRiveFileFactorySpec::initHybrid),
+      makeNativeMethod("initHybrid", JHybridRiveFileFactorySpec::CxxPart::initHybrid),
     });
   }
 
-  size_t JHybridRiveFileFactorySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridRiveFileFactorySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridRiveFileFactorySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
-    }
-    return false;
-  }
-
-  void JHybridRiveFileFactorySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridRiveFileFactorySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
-  }
-
   // Properties
-  
+
 
   // Methods
   std::shared_ptr<Promise<std::shared_ptr<HybridRiveFileSpec>>> JHybridRiveFileFactorySpec::fromURL(const std::string& url, bool loadCdn, const std::optional<ReferencedAssetsType>& referencedAssets) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* url */, jboolean /* loadCdn */, jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("fromURL");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* url */, jboolean /* loadCdn */, jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("fromURL");
     auto __result = method(_javaPart, jni::make_jstring(url), loadCdn, referencedAssets.has_value() ? JReferencedAssetsType::fromCpp(referencedAssets.value()) : nullptr);
     return [&]() {
       auto __promise = Promise<std::shared_ptr<HybridRiveFileSpec>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JHybridRiveFileSpec::javaobject>(__boxedResult);
-        __promise->resolve(__result->cthis()->shared_cast<JHybridRiveFileSpec>());
+        auto __result = jni::static_ref_cast<JHybridRiveFileSpec::JavaPart>(__boxedResult);
+        __promise->resolve(__result->getJHybridRiveFileSpec());
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);
@@ -89,13 +83,13 @@ namespace margelo::nitro::rive {
     }();
   }
   std::shared_ptr<Promise<std::shared_ptr<HybridRiveFileSpec>>> JHybridRiveFileFactorySpec::fromFileURL(const std::string& fileURL, bool loadCdn, const std::optional<ReferencedAssetsType>& referencedAssets) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* fileURL */, jboolean /* loadCdn */, jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("fromFileURL");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* fileURL */, jboolean /* loadCdn */, jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("fromFileURL");
     auto __result = method(_javaPart, jni::make_jstring(fileURL), loadCdn, referencedAssets.has_value() ? JReferencedAssetsType::fromCpp(referencedAssets.value()) : nullptr);
     return [&]() {
       auto __promise = Promise<std::shared_ptr<HybridRiveFileSpec>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JHybridRiveFileSpec::javaobject>(__boxedResult);
-        __promise->resolve(__result->cthis()->shared_cast<JHybridRiveFileSpec>());
+        auto __result = jni::static_ref_cast<JHybridRiveFileSpec::JavaPart>(__boxedResult);
+        __promise->resolve(__result->getJHybridRiveFileSpec());
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);
@@ -105,13 +99,13 @@ namespace margelo::nitro::rive {
     }();
   }
   std::shared_ptr<Promise<std::shared_ptr<HybridRiveFileSpec>>> JHybridRiveFileFactorySpec::fromResource(const std::string& resource, bool loadCdn, const std::optional<ReferencedAssetsType>& referencedAssets) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* resource */, jboolean /* loadCdn */, jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("fromResource");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* resource */, jboolean /* loadCdn */, jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("fromResource");
     auto __result = method(_javaPart, jni::make_jstring(resource), loadCdn, referencedAssets.has_value() ? JReferencedAssetsType::fromCpp(referencedAssets.value()) : nullptr);
     return [&]() {
       auto __promise = Promise<std::shared_ptr<HybridRiveFileSpec>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JHybridRiveFileSpec::javaobject>(__boxedResult);
-        __promise->resolve(__result->cthis()->shared_cast<JHybridRiveFileSpec>());
+        auto __result = jni::static_ref_cast<JHybridRiveFileSpec::JavaPart>(__boxedResult);
+        __promise->resolve(__result->getJHybridRiveFileSpec());
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);
@@ -121,13 +115,13 @@ namespace margelo::nitro::rive {
     }();
   }
   std::shared_ptr<Promise<std::shared_ptr<HybridRiveFileSpec>>> JHybridRiveFileFactorySpec::fromBytes(const std::shared_ptr<ArrayBuffer>& bytes, bool loadCdn, const std::optional<ReferencedAssetsType>& referencedAssets) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JArrayBuffer::javaobject> /* bytes */, jboolean /* loadCdn */, jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("fromBytes");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JArrayBuffer::javaobject> /* bytes */, jboolean /* loadCdn */, jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("fromBytes");
     auto __result = method(_javaPart, JArrayBuffer::wrap(bytes), loadCdn, referencedAssets.has_value() ? JReferencedAssetsType::fromCpp(referencedAssets.value()) : nullptr);
     return [&]() {
       auto __promise = Promise<std::shared_ptr<HybridRiveFileSpec>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JHybridRiveFileSpec::javaobject>(__boxedResult);
-        __promise->resolve(__result->cthis()->shared_cast<JHybridRiveFileSpec>());
+        auto __result = jni::static_ref_cast<JHybridRiveFileSpec::JavaPart>(__boxedResult);
+        __promise->resolve(__result->getJHybridRiveFileSpec());
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);

--- a/nitrogen/generated/android/c++/JHybridRiveFileFactorySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridRiveFileFactorySpec.hpp
@@ -18,40 +18,39 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridRiveFileFactorySpec: public jni::HybridClass<JHybridRiveFileFactorySpec, JHybridObject>,
-                                    public virtual HybridRiveFileFactorySpec {
+  class JHybridRiveFileFactorySpec: public virtual HybridRiveFileFactorySpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveFileFactorySpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveFileFactorySpec;";
+      std::shared_ptr<JHybridRiveFileFactorySpec> getJHybridRiveFileFactorySpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveFileFactorySpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridRiveFileFactorySpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridRiveFileFactorySpec(const jni::local_ref<JHybridRiveFileFactorySpec::JavaPart>& javaPart):
       HybridObject(HybridRiveFileFactorySpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridRiveFileFactorySpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridRiveFileFactorySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridRiveFileFactorySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
   public:
     // Properties
-    
+
 
   public:
     // Methods
@@ -61,9 +60,7 @@ namespace margelo::nitro::rive {
     std::shared_ptr<Promise<std::shared_ptr<HybridRiveFileSpec>>> fromBytes(const std::shared_ptr<ArrayBuffer>& bytes, bool loadCdn, const std::optional<ReferencedAssetsType>& referencedAssets) override;
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridRiveFileFactorySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridRiveFileFactorySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridRiveFileSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridRiveFileSpec.cpp
@@ -44,52 +44,46 @@ namespace margelo::nitro::rive { class HybridRiveImageSpec; }
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridRiveFileSpec::jhybriddata> JHybridRiveFileSpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridRiveFileSpec> JHybridRiveFileSpec::JavaPart::getJHybridRiveFileSpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridRiveFileSpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridRiveFileSpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridRiveFileSpec::CxxPart::jhybriddata> JHybridRiveFileSpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridRiveFileSpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridRiveFileSpec::initHybrid),
-    });
-  }
-
-  size_t JHybridRiveFileSpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridRiveFileSpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridRiveFileSpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridRiveFileSpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridRiveFileSpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridRiveFileSpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridRiveFileSpec>(castJavaPart);
   }
 
-  void JHybridRiveFileSpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridRiveFileSpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridRiveFileSpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridRiveFileSpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   std::optional<double> JHybridRiveFileSpec::getViewModelCount() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JDouble>()>("getViewModelCount");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JDouble>()>("getViewModelCount");
     auto __result = method(_javaPart);
     return __result != nullptr ? std::make_optional(__result->value()) : std::nullopt;
   }
   double JHybridRiveFileSpec::getArtboardCount() {
-    static const auto method = javaClassStatic()->getMethod<double()>("getArtboardCount");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getArtboardCount");
     auto __result = method(_javaPart);
     return __result;
   }
   std::vector<std::string> JHybridRiveFileSpec::getArtboardNames() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>("getArtboardNames");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>("getArtboardNames");
     auto __result = method(_javaPart);
     return [&]() {
       size_t __size = __result->size();
@@ -105,28 +99,28 @@ namespace margelo::nitro::rive {
 
   // Methods
   std::optional<std::shared_ptr<HybridViewModelSpec>> JHybridRiveFileSpec::viewModelByIndex(double index) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelSpec::javaobject>(double /* index */)>("viewModelByIndex");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelSpec::JavaPart>(double /* index */)>("viewModelByIndex");
     auto __result = method(_javaPart, index);
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelSpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelSpec>> JHybridRiveFileSpec::viewModelByName(const std::string& name) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelSpec::javaobject>(jni::alias_ref<jni::JString> /* name */)>("viewModelByName");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelSpec::JavaPart>(jni::alias_ref<jni::JString> /* name */)>("viewModelByName");
     auto __result = method(_javaPart, jni::make_jstring(name));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelSpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelSpec>> JHybridRiveFileSpec::defaultArtboardViewModel(const std::optional<ArtboardBy>& artboardBy) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelSpec::javaobject>(jni::alias_ref<JArtboardBy> /* artboardBy */)>("defaultArtboardViewModel");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelSpec::JavaPart>(jni::alias_ref<JArtboardBy> /* artboardBy */)>("defaultArtboardViewModel");
     auto __result = method(_javaPart, artboardBy.has_value() ? JArtboardBy::fromCpp(artboardBy.value()) : nullptr);
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelSpec()) : std::nullopt;
   }
   void JHybridRiveFileSpec::updateReferencedAssets(const ReferencedAssetsType& referencedAssets) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("updateReferencedAssets");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JReferencedAssetsType> /* referencedAssets */)>("updateReferencedAssets");
     method(_javaPart, JReferencedAssetsType::fromCpp(referencedAssets));
   }
   std::shared_ptr<HybridBindableArtboardSpec> JHybridRiveFileSpec::getBindableArtboard(const std::string& name) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridBindableArtboardSpec::javaobject>(jni::alias_ref<jni::JString> /* name */)>("getBindableArtboard");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridBindableArtboardSpec::JavaPart>(jni::alias_ref<jni::JString> /* name */)>("getBindableArtboard");
     auto __result = method(_javaPart, jni::make_jstring(name));
-    return __result->cthis()->shared_cast<JHybridBindableArtboardSpec>();
+    return __result->getJHybridBindableArtboardSpec();
   }
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridRiveFileSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridRiveFileSpec.hpp
@@ -18,34 +18,33 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridRiveFileSpec: public jni::HybridClass<JHybridRiveFileSpec, JHybridObject>,
-                             public virtual HybridRiveFileSpec {
+  class JHybridRiveFileSpec: public virtual HybridRiveFileSpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveFileSpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveFileSpec;";
+      std::shared_ptr<JHybridRiveFileSpec> getJHybridRiveFileSpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveFileSpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridRiveFileSpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridRiveFileSpec(const jni::local_ref<JHybridRiveFileSpec::JavaPart>& javaPart):
       HybridObject(HybridRiveFileSpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridRiveFileSpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridRiveFileSpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridRiveFileSpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -64,9 +63,7 @@ namespace margelo::nitro::rive {
     std::shared_ptr<HybridBindableArtboardSpec> getBindableArtboard(const std::string& name) override;
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridRiveFileSpec::javaobject> _javaPart;
+    jni::global_ref<JHybridRiveFileSpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridRiveImageFactorySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridRiveImageFactorySpec.cpp
@@ -21,51 +21,45 @@ namespace margelo::nitro::rive { class HybridRiveImageSpec; }
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridRiveImageFactorySpec::jhybriddata> JHybridRiveImageFactorySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridRiveImageFactorySpec> JHybridRiveImageFactorySpec::JavaPart::getJHybridRiveImageFactorySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridRiveImageFactorySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridRiveImageFactorySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridRiveImageFactorySpec::CxxPart::jhybriddata> JHybridRiveImageFactorySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridRiveImageFactorySpec::registerNatives() {
+  std::shared_ptr<JHybridObject> JHybridRiveImageFactorySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridRiveImageFactorySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridRiveImageFactorySpec::JavaPart!");
+    }
+    return std::make_shared<JHybridRiveImageFactorySpec>(castJavaPart);
+  }
+
+  void JHybridRiveImageFactorySpec::CxxPart::registerNatives() {
     registerHybrid({
-      makeNativeMethod("initHybrid", JHybridRiveImageFactorySpec::initHybrid),
+      makeNativeMethod("initHybrid", JHybridRiveImageFactorySpec::CxxPart::initHybrid),
     });
   }
 
-  size_t JHybridRiveImageFactorySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridRiveImageFactorySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridRiveImageFactorySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
-    }
-    return false;
-  }
-
-  void JHybridRiveImageFactorySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridRiveImageFactorySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
-  }
-
   // Properties
-  
+
 
   // Methods
   std::shared_ptr<Promise<std::shared_ptr<HybridRiveImageSpec>>> JHybridRiveImageFactorySpec::loadFromURLAsync(const std::string& url) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* url */)>("loadFromURLAsync");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* url */)>("loadFromURLAsync");
     auto __result = method(_javaPart, jni::make_jstring(url));
     return [&]() {
       auto __promise = Promise<std::shared_ptr<HybridRiveImageSpec>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JHybridRiveImageSpec::javaobject>(__boxedResult);
-        __promise->resolve(__result->cthis()->shared_cast<JHybridRiveImageSpec>());
+        auto __result = jni::static_ref_cast<JHybridRiveImageSpec::JavaPart>(__boxedResult);
+        __promise->resolve(__result->getJHybridRiveImageSpec());
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);
@@ -75,13 +69,13 @@ namespace margelo::nitro::rive {
     }();
   }
   std::shared_ptr<Promise<std::shared_ptr<HybridRiveImageSpec>>> JHybridRiveImageFactorySpec::loadFromResourceAsync(const std::string& resource) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* resource */)>("loadFromResourceAsync");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* resource */)>("loadFromResourceAsync");
     auto __result = method(_javaPart, jni::make_jstring(resource));
     return [&]() {
       auto __promise = Promise<std::shared_ptr<HybridRiveImageSpec>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JHybridRiveImageSpec::javaobject>(__boxedResult);
-        __promise->resolve(__result->cthis()->shared_cast<JHybridRiveImageSpec>());
+        auto __result = jni::static_ref_cast<JHybridRiveImageSpec::JavaPart>(__boxedResult);
+        __promise->resolve(__result->getJHybridRiveImageSpec());
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);
@@ -91,13 +85,13 @@ namespace margelo::nitro::rive {
     }();
   }
   std::shared_ptr<Promise<std::shared_ptr<HybridRiveImageSpec>>> JHybridRiveImageFactorySpec::loadFromBytesAsync(const std::shared_ptr<ArrayBuffer>& bytes) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JArrayBuffer::javaobject> /* bytes */)>("loadFromBytesAsync");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<JArrayBuffer::javaobject> /* bytes */)>("loadFromBytesAsync");
     auto __result = method(_javaPart, JArrayBuffer::wrap(bytes));
     return [&]() {
       auto __promise = Promise<std::shared_ptr<HybridRiveImageSpec>>::create();
       __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& __boxedResult) {
-        auto __result = jni::static_ref_cast<JHybridRiveImageSpec::javaobject>(__boxedResult);
-        __promise->resolve(__result->cthis()->shared_cast<JHybridRiveImageSpec>());
+        auto __result = jni::static_ref_cast<JHybridRiveImageSpec::JavaPart>(__boxedResult);
+        __promise->resolve(__result->getJHybridRiveImageSpec());
       });
       __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
         jni::JniException __jniError(__throwable);

--- a/nitrogen/generated/android/c++/JHybridRiveImageFactorySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridRiveImageFactorySpec.hpp
@@ -18,40 +18,39 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridRiveImageFactorySpec: public jni::HybridClass<JHybridRiveImageFactorySpec, JHybridObject>,
-                                     public virtual HybridRiveImageFactorySpec {
+  class JHybridRiveImageFactorySpec: public virtual HybridRiveImageFactorySpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveImageFactorySpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveImageFactorySpec;";
+      std::shared_ptr<JHybridRiveImageFactorySpec> getJHybridRiveImageFactorySpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveImageFactorySpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridRiveImageFactorySpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridRiveImageFactorySpec(const jni::local_ref<JHybridRiveImageFactorySpec::JavaPart>& javaPart):
       HybridObject(HybridRiveImageFactorySpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridRiveImageFactorySpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridRiveImageFactorySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridRiveImageFactorySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
   public:
     // Properties
-    
+
 
   public:
     // Methods
@@ -60,9 +59,7 @@ namespace margelo::nitro::rive {
     std::shared_ptr<Promise<std::shared_ptr<HybridRiveImageSpec>>> loadFromBytesAsync(const std::shared_ptr<ArrayBuffer>& bytes) override;
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridRiveImageFactorySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridRiveImageFactorySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridRiveImageSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridRiveImageSpec.cpp
@@ -13,42 +13,36 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridRiveImageSpec::jhybriddata> JHybridRiveImageSpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridRiveImageSpec> JHybridRiveImageSpec::JavaPart::getJHybridRiveImageSpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridRiveImageSpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridRiveImageSpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridRiveImageSpec::CxxPart::jhybriddata> JHybridRiveImageSpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridRiveImageSpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridRiveImageSpec::initHybrid),
-    });
-  }
-
-  size_t JHybridRiveImageSpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridRiveImageSpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridRiveImageSpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridRiveImageSpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridRiveImageSpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridRiveImageSpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridRiveImageSpec>(castJavaPart);
   }
 
-  void JHybridRiveImageSpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridRiveImageSpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridRiveImageSpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridRiveImageSpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   double JHybridRiveImageSpec::getByteSize() {
-    static const auto method = javaClassStatic()->getMethod<double()>("getByteSize");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getByteSize");
     auto __result = method(_javaPart);
     return __result;
   }

--- a/nitrogen/generated/android/c++/JHybridRiveImageSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridRiveImageSpec.hpp
@@ -18,34 +18,33 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridRiveImageSpec: public jni::HybridClass<JHybridRiveImageSpec, JHybridObject>,
-                              public virtual HybridRiveImageSpec {
+  class JHybridRiveImageSpec: public virtual HybridRiveImageSpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveImageSpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveImageSpec;";
+      std::shared_ptr<JHybridRiveImageSpec> getJHybridRiveImageSpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveImageSpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridRiveImageSpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridRiveImageSpec(const jni::local_ref<JHybridRiveImageSpec::JavaPart>& javaPart):
       HybridObject(HybridRiveImageSpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridRiveImageSpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridRiveImageSpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridRiveImageSpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -58,9 +57,7 @@ namespace margelo::nitro::rive {
     
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridRiveImageSpec::javaobject> _javaPart;
+    jni::global_ref<JHybridRiveImageSpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridRiveRuntimeSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridRiveRuntimeSpec.cpp
@@ -17,54 +17,48 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridRiveRuntimeSpec::jhybriddata> JHybridRiveRuntimeSpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridRiveRuntimeSpec> JHybridRiveRuntimeSpec::JavaPart::getJHybridRiveRuntimeSpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridRiveRuntimeSpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridRiveRuntimeSpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridRiveRuntimeSpec::CxxPart::jhybriddata> JHybridRiveRuntimeSpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridRiveRuntimeSpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridRiveRuntimeSpec::initHybrid),
-    });
-  }
-
-  size_t JHybridRiveRuntimeSpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridRiveRuntimeSpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridRiveRuntimeSpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridRiveRuntimeSpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridRiveRuntimeSpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridRiveRuntimeSpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridRiveRuntimeSpec>(castJavaPart);
   }
 
-  void JHybridRiveRuntimeSpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridRiveRuntimeSpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridRiveRuntimeSpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridRiveRuntimeSpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   bool JHybridRiveRuntimeSpec::getIsInitialized() {
-    static const auto method = javaClassStatic()->getMethod<jboolean()>("isInitialized");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("isInitialized");
     auto __result = method(_javaPart);
     return static_cast<bool>(__result);
   }
   std::optional<std::string> JHybridRiveRuntimeSpec::getInitError() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getInitError");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getInitError");
     auto __result = method(_javaPart);
     return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
   }
 
   // Methods
   std::shared_ptr<Promise<void>> JHybridRiveRuntimeSpec::initialize() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("initialize");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("initialize");
     auto __result = method(_javaPart);
     return [&]() {
       auto __promise = Promise<void>::create();

--- a/nitrogen/generated/android/c++/JHybridRiveRuntimeSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridRiveRuntimeSpec.hpp
@@ -18,34 +18,33 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridRiveRuntimeSpec: public jni::HybridClass<JHybridRiveRuntimeSpec, JHybridObject>,
-                                public virtual HybridRiveRuntimeSpec {
+  class JHybridRiveRuntimeSpec: public virtual HybridRiveRuntimeSpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveRuntimeSpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveRuntimeSpec;";
+      std::shared_ptr<JHybridRiveRuntimeSpec> getJHybridRiveRuntimeSpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveRuntimeSpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridRiveRuntimeSpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridRiveRuntimeSpec(const jni::local_ref<JHybridRiveRuntimeSpec::JavaPart>& javaPart):
       HybridObject(HybridRiveRuntimeSpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridRiveRuntimeSpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridRiveRuntimeSpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridRiveRuntimeSpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -59,9 +58,7 @@ namespace margelo::nitro::rive {
     std::shared_ptr<Promise<void>> initialize() override;
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridRiveRuntimeSpec::javaobject> _javaPart;
+    jni::global_ref<JHybridRiveRuntimeSpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridRiveSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridRiveSpec.cpp
@@ -13,45 +13,39 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridRiveSpec::jhybriddata> JHybridRiveSpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridRiveSpec> JHybridRiveSpec::JavaPart::getJHybridRiveSpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridRiveSpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridRiveSpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridRiveSpec::CxxPart::jhybriddata> JHybridRiveSpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridRiveSpec::registerNatives() {
+  std::shared_ptr<JHybridObject> JHybridRiveSpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridRiveSpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridRiveSpec::JavaPart!");
+    }
+    return std::make_shared<JHybridRiveSpec>(castJavaPart);
+  }
+
+  void JHybridRiveSpec::CxxPart::registerNatives() {
     registerHybrid({
-      makeNativeMethod("initHybrid", JHybridRiveSpec::initHybrid),
+      makeNativeMethod("initHybrid", JHybridRiveSpec::CxxPart::initHybrid),
     });
   }
 
-  size_t JHybridRiveSpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridRiveSpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridRiveSpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
-    }
-    return false;
-  }
-
-  void JHybridRiveSpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridRiveSpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
-  }
-
   // Properties
-  
+
 
   // Methods
   double JHybridRiveSpec::multiply(double a, double b) {
-    static const auto method = javaClassStatic()->getMethod<double(double /* a */, double /* b */)>("multiply");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double(double /* a */, double /* b */)>("multiply");
     auto __result = method(_javaPart, a, b);
     return __result;
   }

--- a/nitrogen/generated/android/c++/JHybridRiveSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridRiveSpec.hpp
@@ -18,49 +18,46 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridRiveSpec: public jni::HybridClass<JHybridRiveSpec, JHybridObject>,
-                         public virtual HybridRiveSpec {
+  class JHybridRiveSpec: public virtual HybridRiveSpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveSpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveSpec;";
+      std::shared_ptr<JHybridRiveSpec> getJHybridRiveSpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveSpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridRiveSpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridRiveSpec(const jni::local_ref<JHybridRiveSpec::JavaPart>& javaPart):
       HybridObject(HybridRiveSpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridRiveSpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridRiveSpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridRiveSpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
   public:
     // Properties
-    
+
 
   public:
     // Methods
     double multiply(double a, double b) override;
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridRiveSpec::javaobject> _javaPart;
+    jni::global_ref<JHybridRiveSpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridRiveViewSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridRiveViewSpec.cpp
@@ -65,114 +65,108 @@ namespace margelo::nitro::rive { enum class RiveEventType; }
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridRiveViewSpec::jhybriddata> JHybridRiveViewSpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridRiveViewSpec> JHybridRiveViewSpec::JavaPart::getJHybridRiveViewSpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridRiveViewSpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridRiveViewSpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridRiveViewSpec::CxxPart::jhybriddata> JHybridRiveViewSpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridRiveViewSpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridRiveViewSpec::initHybrid),
-    });
-  }
-
-  size_t JHybridRiveViewSpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridRiveViewSpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridRiveViewSpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridRiveViewSpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridRiveViewSpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridRiveViewSpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridRiveViewSpec>(castJavaPart);
   }
 
-  void JHybridRiveViewSpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridRiveViewSpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridRiveViewSpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridRiveViewSpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   std::optional<std::string> JHybridRiveViewSpec::getArtboardName() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getArtboardName");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getArtboardName");
     auto __result = method(_javaPart);
     return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
   }
   void JHybridRiveViewSpec::setArtboardName(const std::optional<std::string>& artboardName) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* artboardName */)>("setArtboardName");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* artboardName */)>("setArtboardName");
     method(_javaPart, artboardName.has_value() ? jni::make_jstring(artboardName.value()) : nullptr);
   }
   std::optional<std::string> JHybridRiveViewSpec::getStateMachineName() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getStateMachineName");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getStateMachineName");
     auto __result = method(_javaPart);
     return __result != nullptr ? std::make_optional(__result->toStdString()) : std::nullopt;
   }
   void JHybridRiveViewSpec::setStateMachineName(const std::optional<std::string>& stateMachineName) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* stateMachineName */)>("setStateMachineName");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* stateMachineName */)>("setStateMachineName");
     method(_javaPart, stateMachineName.has_value() ? jni::make_jstring(stateMachineName.value()) : nullptr);
   }
   std::optional<bool> JHybridRiveViewSpec::getAutoPlay() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JBoolean>()>("getAutoPlay");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JBoolean>()>("getAutoPlay");
     auto __result = method(_javaPart);
     return __result != nullptr ? std::make_optional(static_cast<bool>(__result->value())) : std::nullopt;
   }
   void JHybridRiveViewSpec::setAutoPlay(std::optional<bool> autoPlay) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* autoPlay */)>("setAutoPlay");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JBoolean> /* autoPlay */)>("setAutoPlay");
     method(_javaPart, autoPlay.has_value() ? jni::JBoolean::valueOf(autoPlay.value()) : nullptr);
   }
   std::shared_ptr<HybridRiveFileSpec> JHybridRiveViewSpec::getFile() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridRiveFileSpec::javaobject>()>("getFile");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridRiveFileSpec::JavaPart>()>("getFile");
     auto __result = method(_javaPart);
-    return __result->cthis()->shared_cast<JHybridRiveFileSpec>();
+    return __result->getJHybridRiveFileSpec();
   }
   void JHybridRiveViewSpec::setFile(const std::shared_ptr<HybridRiveFileSpec>& file) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JHybridRiveFileSpec::javaobject> /* file */)>("setFile");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JHybridRiveFileSpec::JavaPart> /* file */)>("setFile");
     method(_javaPart, std::dynamic_pointer_cast<JHybridRiveFileSpec>(file)->getJavaPart());
   }
   std::optional<Alignment> JHybridRiveViewSpec::getAlignment() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JAlignment>()>("getAlignment");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JAlignment>()>("getAlignment");
     auto __result = method(_javaPart);
     return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   void JHybridRiveViewSpec::setAlignment(std::optional<Alignment> alignment) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JAlignment> /* alignment */)>("setAlignment");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JAlignment> /* alignment */)>("setAlignment");
     method(_javaPart, alignment.has_value() ? JAlignment::fromCpp(alignment.value()) : nullptr);
   }
   std::optional<Fit> JHybridRiveViewSpec::getFit() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFit>()>("getFit");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFit>()>("getFit");
     auto __result = method(_javaPart);
     return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   void JHybridRiveViewSpec::setFit(std::optional<Fit> fit) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JFit> /* fit */)>("setFit");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFit> /* fit */)>("setFit");
     method(_javaPart, fit.has_value() ? JFit::fromCpp(fit.value()) : nullptr);
   }
   std::optional<double> JHybridRiveViewSpec::getLayoutScaleFactor() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JDouble>()>("getLayoutScaleFactor");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JDouble>()>("getLayoutScaleFactor");
     auto __result = method(_javaPart);
     return __result != nullptr ? std::make_optional(__result->value()) : std::nullopt;
   }
   void JHybridRiveViewSpec::setLayoutScaleFactor(std::optional<double> layoutScaleFactor) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JDouble> /* layoutScaleFactor */)>("setLayoutScaleFactor");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JDouble> /* layoutScaleFactor */)>("setLayoutScaleFactor");
     method(_javaPart, layoutScaleFactor.has_value() ? jni::JDouble::valueOf(layoutScaleFactor.value()) : nullptr);
   }
   std::optional<std::variant<std::shared_ptr<HybridViewModelInstanceSpec>, DataBindMode, DataBindByName>> JHybridRiveViewSpec::getDataBind() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName>()>("getDataBind");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName>()>("getDataBind");
     auto __result = method(_javaPart);
     return __result != nullptr ? std::make_optional(__result->toCpp()) : std::nullopt;
   }
   void JHybridRiveViewSpec::setDataBind(const std::optional<std::variant<std::shared_ptr<HybridViewModelInstanceSpec>, DataBindMode, DataBindByName>>& dataBind) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName> /* dataBind */)>("setDataBind");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName> /* dataBind */)>("setDataBind");
     method(_javaPart, dataBind.has_value() ? JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName::fromCpp(dataBind.value()) : nullptr);
   }
   std::function<void(const RiveError& /* error */)> JHybridRiveViewSpec::getOnError() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void_RiveError::javaobject>()>("getOnError_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void_RiveError::javaobject>()>("getOnError_cxx");
     auto __result = method(_javaPart);
     return [&]() -> std::function<void(const RiveError& /* error */)> {
       if (__result->isInstanceOf(JFunc_void_RiveError_cxx::javaClassStatic())) [[likely]] {
@@ -185,13 +179,13 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridRiveViewSpec::setOnError(const std::function<void(const RiveError& /* error */)>& onError) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void_RiveError::javaobject> /* onError */)>("setOnError_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void_RiveError::javaobject> /* onError */)>("setOnError_cxx");
     method(_javaPart, JFunc_void_RiveError_cxx::fromCpp(onError));
   }
 
   // Methods
   std::shared_ptr<Promise<bool>> JHybridRiveViewSpec::awaitViewReady() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("awaitViewReady");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("awaitViewReady");
     auto __result = method(_javaPart);
     return [&]() {
       auto __promise = Promise<bool>::create();
@@ -207,16 +201,16 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridRiveViewSpec::bindViewModelInstance(const std::shared_ptr<HybridViewModelInstanceSpec>& viewModelInstance) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JHybridViewModelInstanceSpec::javaobject> /* viewModelInstance */)>("bindViewModelInstance");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JHybridViewModelInstanceSpec::JavaPart> /* viewModelInstance */)>("bindViewModelInstance");
     method(_javaPart, std::dynamic_pointer_cast<JHybridViewModelInstanceSpec>(viewModelInstance)->getJavaPart());
   }
   std::optional<std::shared_ptr<HybridViewModelInstanceSpec>> JHybridRiveViewSpec::getViewModelInstance() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::javaobject>()>("getViewModelInstance");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::JavaPart>()>("getViewModelInstance");
     auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelInstanceSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelInstanceSpec()) : std::nullopt;
   }
   std::shared_ptr<Promise<void>> JHybridRiveViewSpec::play() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("play");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("play");
     auto __result = method(_javaPart);
     return [&]() {
       auto __promise = Promise<void>::create();
@@ -231,7 +225,7 @@ namespace margelo::nitro::rive {
     }();
   }
   std::shared_ptr<Promise<void>> JHybridRiveViewSpec::pause() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("pause");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("pause");
     auto __result = method(_javaPart);
     return [&]() {
       auto __promise = Promise<void>::create();
@@ -246,7 +240,7 @@ namespace margelo::nitro::rive {
     }();
   }
   std::shared_ptr<Promise<void>> JHybridRiveViewSpec::reset() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("reset");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>()>("reset");
     auto __result = method(_javaPart);
     return [&]() {
       auto __promise = Promise<void>::create();
@@ -261,45 +255,45 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridRiveViewSpec::playIfNeeded() {
-    static const auto method = javaClassStatic()->getMethod<void()>("playIfNeeded");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("playIfNeeded");
     method(_javaPart);
   }
   void JHybridRiveViewSpec::onEventListener(const std::function<void(const UnifiedRiveEvent& /* event */)>& onEvent) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void_UnifiedRiveEvent::javaobject> /* onEvent */)>("onEventListener_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JFunc_void_UnifiedRiveEvent::javaobject> /* onEvent */)>("onEventListener_cxx");
     method(_javaPart, JFunc_void_UnifiedRiveEvent_cxx::fromCpp(onEvent));
   }
   void JHybridRiveViewSpec::removeEventListeners() {
-    static const auto method = javaClassStatic()->getMethod<void()>("removeEventListeners");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("removeEventListeners");
     method(_javaPart);
   }
   void JHybridRiveViewSpec::setNumberInputValue(const std::string& name, double value, const std::optional<std::string>& path) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* name */, double /* value */, jni::alias_ref<jni::JString> /* path */)>("setNumberInputValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* name */, double /* value */, jni::alias_ref<jni::JString> /* path */)>("setNumberInputValue");
     method(_javaPart, jni::make_jstring(name), value, path.has_value() ? jni::make_jstring(path.value()) : nullptr);
   }
   double JHybridRiveViewSpec::getNumberInputValue(const std::string& name, const std::optional<std::string>& path) {
-    static const auto method = javaClassStatic()->getMethod<double(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* path */)>("getNumberInputValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* path */)>("getNumberInputValue");
     auto __result = method(_javaPart, jni::make_jstring(name), path.has_value() ? jni::make_jstring(path.value()) : nullptr);
     return __result;
   }
   void JHybridRiveViewSpec::setBooleanInputValue(const std::string& name, bool value, const std::optional<std::string>& path) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* name */, jboolean /* value */, jni::alias_ref<jni::JString> /* path */)>("setBooleanInputValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* name */, jboolean /* value */, jni::alias_ref<jni::JString> /* path */)>("setBooleanInputValue");
     method(_javaPart, jni::make_jstring(name), value, path.has_value() ? jni::make_jstring(path.value()) : nullptr);
   }
   bool JHybridRiveViewSpec::getBooleanInputValue(const std::string& name, const std::optional<std::string>& path) {
-    static const auto method = javaClassStatic()->getMethod<jboolean(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* path */)>("getBooleanInputValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* path */)>("getBooleanInputValue");
     auto __result = method(_javaPart, jni::make_jstring(name), path.has_value() ? jni::make_jstring(path.value()) : nullptr);
     return static_cast<bool>(__result);
   }
   void JHybridRiveViewSpec::triggerInput(const std::string& name, const std::optional<std::string>& path) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* path */)>("triggerInput");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* path */)>("triggerInput");
     method(_javaPart, jni::make_jstring(name), path.has_value() ? jni::make_jstring(path.value()) : nullptr);
   }
   void JHybridRiveViewSpec::setTextRunValue(const std::string& name, const std::string& value, const std::optional<std::string>& path) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* value */, jni::alias_ref<jni::JString> /* path */)>("setTextRunValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* value */, jni::alias_ref<jni::JString> /* path */)>("setTextRunValue");
     method(_javaPart, jni::make_jstring(name), jni::make_jstring(value), path.has_value() ? jni::make_jstring(path.value()) : nullptr);
   }
   std::string JHybridRiveViewSpec::getTextRunValue(const std::string& name, const std::optional<std::string>& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* path */)>("getTextRunValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>(jni::alias_ref<jni::JString> /* name */, jni::alias_ref<jni::JString> /* path */)>("getTextRunValue");
     auto __result = method(_javaPart, jni::make_jstring(name), path.has_value() ? jni::make_jstring(path.value()) : nullptr);
     return __result->toStdString();
   }

--- a/nitrogen/generated/android/c++/JHybridRiveViewSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridRiveViewSpec.hpp
@@ -18,34 +18,33 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridRiveViewSpec: public jni::HybridClass<JHybridRiveViewSpec, JHybridObject>,
-                             public virtual HybridRiveViewSpec {
+  class JHybridRiveViewSpec: public virtual HybridRiveViewSpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveViewSpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveViewSpec;";
+      std::shared_ptr<JHybridRiveViewSpec> getJHybridRiveViewSpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveViewSpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridRiveViewSpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridRiveViewSpec(const jni::local_ref<JHybridRiveViewSpec::JavaPart>& javaPart):
       HybridObject(HybridRiveViewSpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridRiveViewSpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridRiveViewSpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridRiveViewSpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -90,9 +89,7 @@ namespace margelo::nitro::rive {
     std::string getTextRunValue(const std::string& name, const std::optional<std::string>& path) override;
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridRiveViewSpec::javaobject> _javaPart;
+    jni::global_ref<JHybridRiveViewSpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelArtboardPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelArtboardPropertySpec.cpp
@@ -17,45 +17,39 @@ namespace margelo::nitro::rive { class HybridBindableArtboardSpec; }
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelArtboardPropertySpec::jhybriddata> JHybridViewModelArtboardPropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelArtboardPropertySpec> JHybridViewModelArtboardPropertySpec::JavaPart::getJHybridViewModelArtboardPropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelArtboardPropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelArtboardPropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelArtboardPropertySpec::CxxPart::jhybriddata> JHybridViewModelArtboardPropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelArtboardPropertySpec::registerNatives() {
+  std::shared_ptr<JHybridObject> JHybridViewModelArtboardPropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelArtboardPropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelArtboardPropertySpec::JavaPart!");
+    }
+    return std::make_shared<JHybridViewModelArtboardPropertySpec>(castJavaPart);
+  }
+
+  void JHybridViewModelArtboardPropertySpec::CxxPart::registerNatives() {
     registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelArtboardPropertySpec::initHybrid),
+      makeNativeMethod("initHybrid", JHybridViewModelArtboardPropertySpec::CxxPart::initHybrid),
     });
   }
 
-  size_t JHybridViewModelArtboardPropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelArtboardPropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelArtboardPropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
-    }
-    return false;
-  }
-
-  void JHybridViewModelArtboardPropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelArtboardPropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
-  }
-
   // Properties
-  
+
 
   // Methods
   void JHybridViewModelArtboardPropertySpec::set(const std::optional<std::shared_ptr<HybridBindableArtboardSpec>>& artboard) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JHybridBindableArtboardSpec::javaobject> /* artboard */)>("set");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JHybridBindableArtboardSpec::JavaPart> /* artboard */)>("set");
     method(_javaPart, artboard.has_value() ? std::dynamic_pointer_cast<JHybridBindableArtboardSpec>(artboard.value())->getJavaPart() : nullptr);
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelArtboardPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelArtboardPropertySpec.hpp
@@ -40,19 +40,13 @@ namespace margelo::nitro::rive {
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelArtboardPropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelArtboardPropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
   public:
     // Properties
-    
+
 
   public:
     // Methods
@@ -61,7 +55,7 @@ namespace margelo::nitro::rive {
   private:
     friend HybridBase;
     using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelArtboardPropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelArtboardPropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelBooleanPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelBooleanPropertySpec.cpp
@@ -16,53 +16,47 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelBooleanPropertySpec::jhybriddata> JHybridViewModelBooleanPropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelBooleanPropertySpec> JHybridViewModelBooleanPropertySpec::JavaPart::getJHybridViewModelBooleanPropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelBooleanPropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelBooleanPropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelBooleanPropertySpec::CxxPart::jhybriddata> JHybridViewModelBooleanPropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelBooleanPropertySpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelBooleanPropertySpec::initHybrid),
-    });
-  }
-
-  size_t JHybridViewModelBooleanPropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelBooleanPropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelBooleanPropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridViewModelBooleanPropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelBooleanPropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelBooleanPropertySpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridViewModelBooleanPropertySpec>(castJavaPart);
   }
 
-  void JHybridViewModelBooleanPropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelBooleanPropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridViewModelBooleanPropertySpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridViewModelBooleanPropertySpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   bool JHybridViewModelBooleanPropertySpec::getValue() {
-    static const auto method = javaClassStatic()->getMethod<jboolean()>("getValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean()>("getValue");
     auto __result = method(_javaPart);
     return static_cast<bool>(__result);
   }
   void JHybridViewModelBooleanPropertySpec::setValue(bool value) {
-    static const auto method = javaClassStatic()->getMethod<void(jboolean /* value */)>("setValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jboolean /* value */)>("setValue");
     method(_javaPart, value);
   }
 
   // Methods
   std::function<void()> JHybridViewModelBooleanPropertySpec::addListener(const std::function<void(bool /* value */)>& onChanged) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_bool::javaobject> /* onChanged */)>("addListener_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_bool::javaobject> /* onChanged */)>("addListener_cxx");
     auto __result = method(_javaPart, JFunc_void_bool_cxx::fromCpp(onChanged));
     return [&]() -> std::function<void()> {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
@@ -75,7 +69,7 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridViewModelBooleanPropertySpec::removeListeners() {
-    static const auto method = javaClassStatic()->getMethod<void()>("removeListeners");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("removeListeners");
     method(_javaPart);
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelBooleanPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelBooleanPropertySpec.hpp
@@ -40,13 +40,7 @@ namespace margelo::nitro::rive {
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelBooleanPropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelBooleanPropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -63,7 +57,7 @@ namespace margelo::nitro::rive {
   private:
     friend HybridBase;
     using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelBooleanPropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelBooleanPropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelColorPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelColorPropertySpec.cpp
@@ -16,53 +16,47 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelColorPropertySpec::jhybriddata> JHybridViewModelColorPropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelColorPropertySpec> JHybridViewModelColorPropertySpec::JavaPart::getJHybridViewModelColorPropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelColorPropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelColorPropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelColorPropertySpec::CxxPart::jhybriddata> JHybridViewModelColorPropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelColorPropertySpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelColorPropertySpec::initHybrid),
-    });
-  }
-
-  size_t JHybridViewModelColorPropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelColorPropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelColorPropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridViewModelColorPropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelColorPropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelColorPropertySpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridViewModelColorPropertySpec>(castJavaPart);
   }
 
-  void JHybridViewModelColorPropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelColorPropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridViewModelColorPropertySpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridViewModelColorPropertySpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   double JHybridViewModelColorPropertySpec::getValue() {
-    static const auto method = javaClassStatic()->getMethod<double()>("getValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getValue");
     auto __result = method(_javaPart);
     return __result;
   }
   void JHybridViewModelColorPropertySpec::setValue(double value) {
-    static const auto method = javaClassStatic()->getMethod<void(double /* value */)>("setValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(double /* value */)>("setValue");
     method(_javaPart, value);
   }
 
   // Methods
   std::function<void()> JHybridViewModelColorPropertySpec::addListener(const std::function<void(double /* value */)>& onChanged) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_double::javaobject> /* onChanged */)>("addListener_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_double::javaobject> /* onChanged */)>("addListener_cxx");
     auto __result = method(_javaPart, JFunc_void_double_cxx::fromCpp(onChanged));
     return [&]() -> std::function<void()> {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
@@ -75,7 +69,7 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridViewModelColorPropertySpec::removeListeners() {
-    static const auto method = javaClassStatic()->getMethod<void()>("removeListeners");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("removeListeners");
     method(_javaPart);
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelColorPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelColorPropertySpec.hpp
@@ -40,13 +40,7 @@ namespace margelo::nitro::rive {
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelColorPropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelColorPropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -63,7 +57,7 @@ namespace margelo::nitro::rive {
   private:
     friend HybridBase;
     using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelColorPropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelColorPropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelEnumPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelEnumPropertySpec.cpp
@@ -17,53 +17,47 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelEnumPropertySpec::jhybriddata> JHybridViewModelEnumPropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelEnumPropertySpec> JHybridViewModelEnumPropertySpec::JavaPart::getJHybridViewModelEnumPropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelEnumPropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelEnumPropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelEnumPropertySpec::CxxPart::jhybriddata> JHybridViewModelEnumPropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelEnumPropertySpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelEnumPropertySpec::initHybrid),
-    });
-  }
-
-  size_t JHybridViewModelEnumPropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelEnumPropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelEnumPropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridViewModelEnumPropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelEnumPropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelEnumPropertySpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridViewModelEnumPropertySpec>(castJavaPart);
   }
 
-  void JHybridViewModelEnumPropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelEnumPropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridViewModelEnumPropertySpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridViewModelEnumPropertySpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   std::string JHybridViewModelEnumPropertySpec::getValue() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getValue");
     auto __result = method(_javaPart);
     return __result->toStdString();
   }
   void JHybridViewModelEnumPropertySpec::setValue(const std::string& value) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* value */)>("setValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* value */)>("setValue");
     method(_javaPart, jni::make_jstring(value));
   }
 
   // Methods
   std::function<void()> JHybridViewModelEnumPropertySpec::addListener(const std::function<void(const std::string& /* value */)>& onChanged) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_std__string::javaobject> /* onChanged */)>("addListener_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_std__string::javaobject> /* onChanged */)>("addListener_cxx");
     auto __result = method(_javaPart, JFunc_void_std__string_cxx::fromCpp(onChanged));
     return [&]() -> std::function<void()> {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
@@ -76,7 +70,7 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridViewModelEnumPropertySpec::removeListeners() {
-    static const auto method = javaClassStatic()->getMethod<void()>("removeListeners");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("removeListeners");
     method(_javaPart);
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelEnumPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelEnumPropertySpec.hpp
@@ -40,13 +40,7 @@ namespace margelo::nitro::rive {
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelEnumPropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelEnumPropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -63,7 +57,7 @@ namespace margelo::nitro::rive {
   private:
     friend HybridBase;
     using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelEnumPropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelEnumPropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelImagePropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelImagePropertySpec.cpp
@@ -20,49 +20,43 @@ namespace margelo::nitro::rive { class HybridRiveImageSpec; }
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelImagePropertySpec::jhybriddata> JHybridViewModelImagePropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelImagePropertySpec> JHybridViewModelImagePropertySpec::JavaPart::getJHybridViewModelImagePropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelImagePropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelImagePropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelImagePropertySpec::CxxPart::jhybriddata> JHybridViewModelImagePropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelImagePropertySpec::registerNatives() {
+  std::shared_ptr<JHybridObject> JHybridViewModelImagePropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelImagePropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelImagePropertySpec::JavaPart!");
+    }
+    return std::make_shared<JHybridViewModelImagePropertySpec>(castJavaPart);
+  }
+
+  void JHybridViewModelImagePropertySpec::CxxPart::registerNatives() {
     registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelImagePropertySpec::initHybrid),
+      makeNativeMethod("initHybrid", JHybridViewModelImagePropertySpec::CxxPart::initHybrid),
     });
   }
 
-  size_t JHybridViewModelImagePropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelImagePropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelImagePropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
-    }
-    return false;
-  }
-
-  void JHybridViewModelImagePropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelImagePropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
-  }
-
   // Properties
-  
+
 
   // Methods
   void JHybridViewModelImagePropertySpec::set(const std::optional<std::shared_ptr<HybridRiveImageSpec>>& image) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JHybridRiveImageSpec::javaobject> /* image */)>("set");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JHybridRiveImageSpec::JavaPart> /* image */)>("set");
     method(_javaPart, image.has_value() ? std::dynamic_pointer_cast<JHybridRiveImageSpec>(image.value())->getJavaPart() : nullptr);
   }
   std::function<void()> JHybridViewModelImagePropertySpec::addListener(const std::function<void()>& onChanged) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void::javaobject> /* onChanged */)>("addListener_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void::javaobject> /* onChanged */)>("addListener_cxx");
     auto __result = method(_javaPart, JFunc_void_cxx::fromCpp(onChanged));
     return [&]() -> std::function<void()> {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
@@ -75,7 +69,7 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridViewModelImagePropertySpec::removeListeners() {
-    static const auto method = javaClassStatic()->getMethod<void()>("removeListeners");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("removeListeners");
     method(_javaPart);
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelImagePropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelImagePropertySpec.hpp
@@ -40,19 +40,13 @@ namespace margelo::nitro::rive {
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelImagePropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelImagePropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
   public:
     // Properties
-    
+
 
   public:
     // Methods
@@ -63,7 +57,7 @@ namespace margelo::nitro::rive {
   private:
     friend HybridBase;
     using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelImagePropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelImagePropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelInstanceSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelInstanceSpec.cpp
@@ -54,99 +54,93 @@ namespace margelo::nitro::rive { class HybridViewModelInstanceSpec; }
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelInstanceSpec::jhybriddata> JHybridViewModelInstanceSpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelInstanceSpec> JHybridViewModelInstanceSpec::JavaPart::getJHybridViewModelInstanceSpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelInstanceSpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelInstanceSpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelInstanceSpec::CxxPart::jhybriddata> JHybridViewModelInstanceSpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelInstanceSpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelInstanceSpec::initHybrid),
-    });
-  }
-
-  size_t JHybridViewModelInstanceSpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelInstanceSpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelInstanceSpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridViewModelInstanceSpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelInstanceSpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelInstanceSpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridViewModelInstanceSpec>(castJavaPart);
   }
 
-  void JHybridViewModelInstanceSpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelInstanceSpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridViewModelInstanceSpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridViewModelInstanceSpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   std::string JHybridViewModelInstanceSpec::getInstanceName() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getInstanceName");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getInstanceName");
     auto __result = method(_javaPart);
     return __result->toStdString();
   }
 
   // Methods
   std::optional<std::shared_ptr<HybridViewModelNumberPropertySpec>> JHybridViewModelInstanceSpec::numberProperty(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelNumberPropertySpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("numberProperty");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelNumberPropertySpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("numberProperty");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelNumberPropertySpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelNumberPropertySpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelStringPropertySpec>> JHybridViewModelInstanceSpec::stringProperty(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelStringPropertySpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("stringProperty");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelStringPropertySpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("stringProperty");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelStringPropertySpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelStringPropertySpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelBooleanPropertySpec>> JHybridViewModelInstanceSpec::booleanProperty(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelBooleanPropertySpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("booleanProperty");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelBooleanPropertySpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("booleanProperty");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelBooleanPropertySpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelBooleanPropertySpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelColorPropertySpec>> JHybridViewModelInstanceSpec::colorProperty(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelColorPropertySpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("colorProperty");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelColorPropertySpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("colorProperty");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelColorPropertySpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelColorPropertySpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelEnumPropertySpec>> JHybridViewModelInstanceSpec::enumProperty(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelEnumPropertySpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("enumProperty");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelEnumPropertySpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("enumProperty");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelEnumPropertySpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelEnumPropertySpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelTriggerPropertySpec>> JHybridViewModelInstanceSpec::triggerProperty(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelTriggerPropertySpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("triggerProperty");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelTriggerPropertySpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("triggerProperty");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelTriggerPropertySpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelTriggerPropertySpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelImagePropertySpec>> JHybridViewModelInstanceSpec::imageProperty(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelImagePropertySpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("imageProperty");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelImagePropertySpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("imageProperty");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelImagePropertySpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelImagePropertySpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelListPropertySpec>> JHybridViewModelInstanceSpec::listProperty(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelListPropertySpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("listProperty");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelListPropertySpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("listProperty");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelListPropertySpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelListPropertySpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelArtboardPropertySpec>> JHybridViewModelInstanceSpec::artboardProperty(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelArtboardPropertySpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("artboardProperty");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelArtboardPropertySpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("artboardProperty");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelArtboardPropertySpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelArtboardPropertySpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelInstanceSpec>> JHybridViewModelInstanceSpec::viewModel(const std::string& path) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::javaobject>(jni::alias_ref<jni::JString> /* path */)>("viewModel");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::JavaPart>(jni::alias_ref<jni::JString> /* path */)>("viewModel");
     auto __result = method(_javaPart, jni::make_jstring(path));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelInstanceSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelInstanceSpec()) : std::nullopt;
   }
   void JHybridViewModelInstanceSpec::replaceViewModel(const std::string& path, const std::shared_ptr<HybridViewModelInstanceSpec>& instance) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* path */, jni::alias_ref<JHybridViewModelInstanceSpec::javaobject> /* instance */)>("replaceViewModel");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* path */, jni::alias_ref<JHybridViewModelInstanceSpec::JavaPart> /* instance */)>("replaceViewModel");
     method(_javaPart, jni::make_jstring(path), std::dynamic_pointer_cast<JHybridViewModelInstanceSpec>(instance)->getJavaPart());
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelInstanceSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelInstanceSpec.hpp
@@ -18,34 +18,33 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridViewModelInstanceSpec: public jni::HybridClass<JHybridViewModelInstanceSpec, JHybridObject>,
-                                      public virtual HybridViewModelInstanceSpec {
+  class JHybridViewModelInstanceSpec: public virtual HybridViewModelInstanceSpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridViewModelInstanceSpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridViewModelInstanceSpec;";
+      std::shared_ptr<JHybridViewModelInstanceSpec> getJHybridViewModelInstanceSpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridViewModelInstanceSpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridViewModelInstanceSpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridViewModelInstanceSpec(const jni::local_ref<JHybridViewModelInstanceSpec::JavaPart>& javaPart):
       HybridObject(HybridViewModelInstanceSpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridViewModelInstanceSpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelInstanceSpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelInstanceSpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -68,9 +67,7 @@ namespace margelo::nitro::rive {
     void replaceViewModel(const std::string& path, const std::shared_ptr<HybridViewModelInstanceSpec>& instance) override;
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelInstanceSpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelInstanceSpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelListPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelListPropertySpec.cpp
@@ -20,76 +20,70 @@ namespace margelo::nitro::rive { class HybridViewModelInstanceSpec; }
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelListPropertySpec::jhybriddata> JHybridViewModelListPropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelListPropertySpec> JHybridViewModelListPropertySpec::JavaPart::getJHybridViewModelListPropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelListPropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelListPropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelListPropertySpec::CxxPart::jhybriddata> JHybridViewModelListPropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelListPropertySpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelListPropertySpec::initHybrid),
-    });
-  }
-
-  size_t JHybridViewModelListPropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelListPropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelListPropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridViewModelListPropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelListPropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelListPropertySpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridViewModelListPropertySpec>(castJavaPart);
   }
 
-  void JHybridViewModelListPropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelListPropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridViewModelListPropertySpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridViewModelListPropertySpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   double JHybridViewModelListPropertySpec::getLength() {
-    static const auto method = javaClassStatic()->getMethod<double()>("getLength");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getLength");
     auto __result = method(_javaPart);
     return __result;
   }
 
   // Methods
   std::optional<std::shared_ptr<HybridViewModelInstanceSpec>> JHybridViewModelListPropertySpec::getInstanceAt(double index) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::javaobject>(double /* index */)>("getInstanceAt");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::JavaPart>(double /* index */)>("getInstanceAt");
     auto __result = method(_javaPart, index);
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelInstanceSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelInstanceSpec()) : std::nullopt;
   }
   void JHybridViewModelListPropertySpec::addInstance(const std::shared_ptr<HybridViewModelInstanceSpec>& instance) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JHybridViewModelInstanceSpec::javaobject> /* instance */)>("addInstance");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JHybridViewModelInstanceSpec::JavaPart> /* instance */)>("addInstance");
     method(_javaPart, std::dynamic_pointer_cast<JHybridViewModelInstanceSpec>(instance)->getJavaPart());
   }
   bool JHybridViewModelListPropertySpec::addInstanceAt(const std::shared_ptr<HybridViewModelInstanceSpec>& instance, double index) {
-    static const auto method = javaClassStatic()->getMethod<jboolean(jni::alias_ref<JHybridViewModelInstanceSpec::javaobject> /* instance */, double /* index */)>("addInstanceAt");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean(jni::alias_ref<JHybridViewModelInstanceSpec::JavaPart> /* instance */, double /* index */)>("addInstanceAt");
     auto __result = method(_javaPart, std::dynamic_pointer_cast<JHybridViewModelInstanceSpec>(instance)->getJavaPart(), index);
     return static_cast<bool>(__result);
   }
   void JHybridViewModelListPropertySpec::removeInstance(const std::shared_ptr<HybridViewModelInstanceSpec>& instance) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<JHybridViewModelInstanceSpec::javaobject> /* instance */)>("removeInstance");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<JHybridViewModelInstanceSpec::JavaPart> /* instance */)>("removeInstance");
     method(_javaPart, std::dynamic_pointer_cast<JHybridViewModelInstanceSpec>(instance)->getJavaPart());
   }
   void JHybridViewModelListPropertySpec::removeInstanceAt(double index) {
-    static const auto method = javaClassStatic()->getMethod<void(double /* index */)>("removeInstanceAt");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(double /* index */)>("removeInstanceAt");
     method(_javaPart, index);
   }
   bool JHybridViewModelListPropertySpec::swap(double index1, double index2) {
-    static const auto method = javaClassStatic()->getMethod<jboolean(double /* index1 */, double /* index2 */)>("swap");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jboolean(double /* index1 */, double /* index2 */)>("swap");
     auto __result = method(_javaPart, index1, index2);
     return static_cast<bool>(__result);
   }
   std::function<void()> JHybridViewModelListPropertySpec::addListener(const std::function<void()>& onChanged) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void::javaobject> /* onChanged */)>("addListener_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void::javaobject> /* onChanged */)>("addListener_cxx");
     auto __result = method(_javaPart, JFunc_void_cxx::fromCpp(onChanged));
     return [&]() -> std::function<void()> {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
@@ -102,7 +96,7 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridViewModelListPropertySpec::removeListeners() {
-    static const auto method = javaClassStatic()->getMethod<void()>("removeListeners");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("removeListeners");
     method(_javaPart);
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelListPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelListPropertySpec.hpp
@@ -40,13 +40,7 @@ namespace margelo::nitro::rive {
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelListPropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelListPropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -68,7 +62,7 @@ namespace margelo::nitro::rive {
   private:
     friend HybridBase;
     using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelListPropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelListPropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelNumberPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelNumberPropertySpec.cpp
@@ -16,53 +16,47 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelNumberPropertySpec::jhybriddata> JHybridViewModelNumberPropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelNumberPropertySpec> JHybridViewModelNumberPropertySpec::JavaPart::getJHybridViewModelNumberPropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelNumberPropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelNumberPropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelNumberPropertySpec::CxxPart::jhybriddata> JHybridViewModelNumberPropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelNumberPropertySpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelNumberPropertySpec::initHybrid),
-    });
-  }
-
-  size_t JHybridViewModelNumberPropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelNumberPropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelNumberPropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridViewModelNumberPropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelNumberPropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelNumberPropertySpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridViewModelNumberPropertySpec>(castJavaPart);
   }
 
-  void JHybridViewModelNumberPropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelNumberPropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridViewModelNumberPropertySpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridViewModelNumberPropertySpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   double JHybridViewModelNumberPropertySpec::getValue() {
-    static const auto method = javaClassStatic()->getMethod<double()>("getValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getValue");
     auto __result = method(_javaPart);
     return __result;
   }
   void JHybridViewModelNumberPropertySpec::setValue(double value) {
-    static const auto method = javaClassStatic()->getMethod<void(double /* value */)>("setValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(double /* value */)>("setValue");
     method(_javaPart, value);
   }
 
   // Methods
   std::function<void()> JHybridViewModelNumberPropertySpec::addListener(const std::function<void(double /* value */)>& onChanged) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_double::javaobject> /* onChanged */)>("addListener_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_double::javaobject> /* onChanged */)>("addListener_cxx");
     auto __result = method(_javaPart, JFunc_void_double_cxx::fromCpp(onChanged));
     return [&]() -> std::function<void()> {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
@@ -75,7 +69,7 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridViewModelNumberPropertySpec::removeListeners() {
-    static const auto method = javaClassStatic()->getMethod<void()>("removeListeners");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("removeListeners");
     method(_javaPart);
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelNumberPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelNumberPropertySpec.hpp
@@ -40,13 +40,7 @@ namespace margelo::nitro::rive {
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelNumberPropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelNumberPropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -63,7 +57,7 @@ namespace margelo::nitro::rive {
   private:
     friend HybridBase;
     using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelNumberPropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelNumberPropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelPropertySpec.cpp
@@ -13,41 +13,35 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelPropertySpec::jhybriddata> JHybridViewModelPropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelPropertySpec> JHybridViewModelPropertySpec::JavaPart::getJHybridViewModelPropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelPropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelPropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelPropertySpec::CxxPart::jhybriddata> JHybridViewModelPropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelPropertySpec::registerNatives() {
+  std::shared_ptr<JHybridObject> JHybridViewModelPropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelPropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelPropertySpec::JavaPart!");
+    }
+    return std::make_shared<JHybridViewModelPropertySpec>(castJavaPart);
+  }
+
+  void JHybridViewModelPropertySpec::CxxPart::registerNatives() {
     registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelPropertySpec::initHybrid),
+      makeNativeMethod("initHybrid", JHybridViewModelPropertySpec::CxxPart::initHybrid),
     });
   }
 
-  size_t JHybridViewModelPropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelPropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelPropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
-    }
-    return false;
-  }
-
-  void JHybridViewModelPropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelPropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
-  }
-
   // Properties
-  
+
 
   // Methods
   

--- a/nitrogen/generated/android/c++/JHybridViewModelPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelPropertySpec.hpp
@@ -18,49 +18,46 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridViewModelPropertySpec: public jni::HybridClass<JHybridViewModelPropertySpec, JHybridObject>,
-                                      public virtual HybridViewModelPropertySpec {
+  class JHybridViewModelPropertySpec: public virtual HybridViewModelPropertySpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridViewModelPropertySpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridViewModelPropertySpec;";
+      std::shared_ptr<JHybridViewModelPropertySpec> getJHybridViewModelPropertySpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridViewModelPropertySpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridViewModelPropertySpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridViewModelPropertySpec(const jni::local_ref<JHybridViewModelPropertySpec::JavaPart>& javaPart):
       HybridObject(HybridViewModelPropertySpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridViewModelPropertySpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelPropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelPropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
   public:
     // Properties
-    
+
 
   public:
     // Methods
     
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelPropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelPropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelSpec.cpp
@@ -18,76 +18,70 @@ namespace margelo::nitro::rive { class HybridViewModelInstanceSpec; }
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelSpec::jhybriddata> JHybridViewModelSpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelSpec> JHybridViewModelSpec::JavaPart::getJHybridViewModelSpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelSpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelSpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelSpec::CxxPart::jhybriddata> JHybridViewModelSpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelSpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelSpec::initHybrid),
-    });
-  }
-
-  size_t JHybridViewModelSpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelSpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelSpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridViewModelSpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelSpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelSpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridViewModelSpec>(castJavaPart);
   }
 
-  void JHybridViewModelSpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelSpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridViewModelSpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridViewModelSpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   double JHybridViewModelSpec::getPropertyCount() {
-    static const auto method = javaClassStatic()->getMethod<double()>("getPropertyCount");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getPropertyCount");
     auto __result = method(_javaPart);
     return __result;
   }
   double JHybridViewModelSpec::getInstanceCount() {
-    static const auto method = javaClassStatic()->getMethod<double()>("getInstanceCount");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<double()>("getInstanceCount");
     auto __result = method(_javaPart);
     return __result;
   }
   std::string JHybridViewModelSpec::getModelName() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getModelName");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getModelName");
     auto __result = method(_javaPart);
     return __result->toStdString();
   }
 
   // Methods
   std::optional<std::shared_ptr<HybridViewModelInstanceSpec>> JHybridViewModelSpec::createInstanceByIndex(double index) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::javaobject>(double /* index */)>("createInstanceByIndex");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::JavaPart>(double /* index */)>("createInstanceByIndex");
     auto __result = method(_javaPart, index);
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelInstanceSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelInstanceSpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelInstanceSpec>> JHybridViewModelSpec::createInstanceByName(const std::string& name) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::javaobject>(jni::alias_ref<jni::JString> /* name */)>("createInstanceByName");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::JavaPart>(jni::alias_ref<jni::JString> /* name */)>("createInstanceByName");
     auto __result = method(_javaPart, jni::make_jstring(name));
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelInstanceSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelInstanceSpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelInstanceSpec>> JHybridViewModelSpec::createDefaultInstance() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::javaobject>()>("createDefaultInstance");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::JavaPart>()>("createDefaultInstance");
     auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelInstanceSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelInstanceSpec()) : std::nullopt;
   }
   std::optional<std::shared_ptr<HybridViewModelInstanceSpec>> JHybridViewModelSpec::createInstance() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::javaobject>()>("createInstance");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JHybridViewModelInstanceSpec::JavaPart>()>("createInstance");
     auto __result = method(_javaPart);
-    return __result != nullptr ? std::make_optional(__result->cthis()->shared_cast<JHybridViewModelInstanceSpec>()) : std::nullopt;
+    return __result != nullptr ? std::make_optional(__result->getJHybridViewModelInstanceSpec()) : std::nullopt;
   }
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelSpec.hpp
@@ -18,34 +18,33 @@ namespace margelo::nitro::rive {
 
   using namespace facebook;
 
-  class JHybridViewModelSpec: public jni::HybridClass<JHybridViewModelSpec, JHybridObject>,
-                              public virtual HybridViewModelSpec {
+  class JHybridViewModelSpec: public virtual HybridViewModelSpec, public virtual JHybridObject {
   public:
-    static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridViewModelSpec;";
-    static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
-    static void registerNatives();
+    struct JavaPart: public jni::JavaClass<JavaPart, JHybridObject::JavaPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridViewModelSpec;";
+      std::shared_ptr<JHybridViewModelSpec> getJHybridViewModelSpec();
+    };
+    struct CxxPart: public jni::HybridClass<CxxPart, JHybridObject::CxxPart> {
+      static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridViewModelSpec$CxxPart;";
+      static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jhybridobject> jThis);
+      static void registerNatives();
+      using HybridBase::HybridBase;
+    protected:
+      std::shared_ptr<JHybridObject> createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) override;
+    };
 
-  protected:
-    // C++ constructor (called from Java via `initHybrid()`)
-    explicit JHybridViewModelSpec(jni::alias_ref<jhybridobject> jThis) :
+  public:
+    explicit JHybridViewModelSpec(const jni::local_ref<JHybridViewModelSpec::JavaPart>& javaPart):
       HybridObject(HybridViewModelSpec::TAG),
-      HybridBase(jThis),
-      _javaPart(jni::make_global(jThis)) {}
-
-  public:
+      JHybridObject(javaPart),
+      _javaPart(jni::make_global(javaPart)) {}
     ~JHybridViewModelSpec() override {
       // Hermes GC can destroy JS objects on a non-JNI Thread.
       jni::ThreadScope::WithClassLoader([&] { _javaPart.reset(); });
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelSpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelSpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -63,9 +62,7 @@ namespace margelo::nitro::rive {
     std::optional<std::shared_ptr<HybridViewModelInstanceSpec>> createInstance() override;
 
   private:
-    friend HybridBase;
-    using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelSpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelSpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelStringPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelStringPropertySpec.cpp
@@ -17,53 +17,47 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelStringPropertySpec::jhybriddata> JHybridViewModelStringPropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelStringPropertySpec> JHybridViewModelStringPropertySpec::JavaPart::getJHybridViewModelStringPropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelStringPropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelStringPropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelStringPropertySpec::CxxPart::jhybriddata> JHybridViewModelStringPropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelStringPropertySpec::registerNatives() {
-    registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelStringPropertySpec::initHybrid),
-    });
-  }
-
-  size_t JHybridViewModelStringPropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelStringPropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelStringPropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
+  std::shared_ptr<JHybridObject> JHybridViewModelStringPropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelStringPropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelStringPropertySpec::JavaPart!");
     }
-    return false;
+    return std::make_shared<JHybridViewModelStringPropertySpec>(castJavaPart);
   }
 
-  void JHybridViewModelStringPropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelStringPropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
+  void JHybridViewModelStringPropertySpec::CxxPart::registerNatives() {
+    registerHybrid({
+      makeNativeMethod("initHybrid", JHybridViewModelStringPropertySpec::CxxPart::initHybrid),
+    });
   }
 
   // Properties
   std::string JHybridViewModelStringPropertySpec::getValue() {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<jni::JString>()>("getValue");
     auto __result = method(_javaPart);
     return __result->toStdString();
   }
   void JHybridViewModelStringPropertySpec::setValue(const std::string& value) {
-    static const auto method = javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* value */)>("setValue");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* value */)>("setValue");
     method(_javaPart, jni::make_jstring(value));
   }
 
   // Methods
   std::function<void()> JHybridViewModelStringPropertySpec::addListener(const std::function<void(const std::string& /* value */)>& onChanged) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_std__string::javaobject> /* onChanged */)>("addListener_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_std__string::javaobject> /* onChanged */)>("addListener_cxx");
     auto __result = method(_javaPart, JFunc_void_std__string_cxx::fromCpp(onChanged));
     return [&]() -> std::function<void()> {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
@@ -76,7 +70,7 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridViewModelStringPropertySpec::removeListeners() {
-    static const auto method = javaClassStatic()->getMethod<void()>("removeListeners");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("removeListeners");
     method(_javaPart);
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelStringPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelStringPropertySpec.hpp
@@ -40,13 +40,7 @@ namespace margelo::nitro::rive {
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelStringPropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelStringPropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
@@ -63,7 +57,7 @@ namespace margelo::nitro::rive {
   private:
     friend HybridBase;
     using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelStringPropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelStringPropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridViewModelTriggerPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelTriggerPropertySpec.cpp
@@ -15,45 +15,39 @@
 
 namespace margelo::nitro::rive {
 
-  jni::local_ref<JHybridViewModelTriggerPropertySpec::jhybriddata> JHybridViewModelTriggerPropertySpec::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  std::shared_ptr<JHybridViewModelTriggerPropertySpec> JHybridViewModelTriggerPropertySpec::JavaPart::getJHybridViewModelTriggerPropertySpec() {
+    auto hybridObject = JHybridObject::JavaPart::getJHybridObject();
+    auto castHybridObject = std::dynamic_pointer_cast<JHybridViewModelTriggerPropertySpec>(hybridObject);
+    if (castHybridObject == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to downcast JHybridObject to JHybridViewModelTriggerPropertySpec!");
+    }
+    return castHybridObject;
+  }
+
+  jni::local_ref<JHybridViewModelTriggerPropertySpec::CxxPart::jhybriddata> JHybridViewModelTriggerPropertySpec::CxxPart::initHybrid(jni::alias_ref<jhybridobject> jThis) {
     return makeCxxInstance(jThis);
   }
 
-  void JHybridViewModelTriggerPropertySpec::registerNatives() {
+  std::shared_ptr<JHybridObject> JHybridViewModelTriggerPropertySpec::CxxPart::createHybridObject(const jni::local_ref<JHybridObject::JavaPart>& javaPart) {
+    auto castJavaPart = jni::dynamic_ref_cast<JHybridViewModelTriggerPropertySpec::JavaPart>(javaPart);
+    if (castJavaPart == nullptr) [[unlikely]] {
+      throw std::runtime_error("Failed to cast JHybridObject::JavaPart to JHybridViewModelTriggerPropertySpec::JavaPart!");
+    }
+    return std::make_shared<JHybridViewModelTriggerPropertySpec>(castJavaPart);
+  }
+
+  void JHybridViewModelTriggerPropertySpec::CxxPart::registerNatives() {
     registerHybrid({
-      makeNativeMethod("initHybrid", JHybridViewModelTriggerPropertySpec::initHybrid),
+      makeNativeMethod("initHybrid", JHybridViewModelTriggerPropertySpec::CxxPart::initHybrid),
     });
   }
 
-  size_t JHybridViewModelTriggerPropertySpec::getExternalMemorySize() noexcept {
-    static const auto method = javaClassStatic()->getMethod<jlong()>("getMemorySize");
-    return method(_javaPart);
-  }
-
-  bool JHybridViewModelTriggerPropertySpec::equals(const std::shared_ptr<HybridObject>& other) {
-    if (auto otherCast = std::dynamic_pointer_cast<JHybridViewModelTriggerPropertySpec>(other)) {
-      return _javaPart == otherCast->_javaPart;
-    }
-    return false;
-  }
-
-  void JHybridViewModelTriggerPropertySpec::dispose() noexcept {
-    static const auto method = javaClassStatic()->getMethod<void()>("dispose");
-    method(_javaPart);
-  }
-
-  std::string JHybridViewModelTriggerPropertySpec::toString() {
-    static const auto method = javaClassStatic()->getMethod<jni::JString()>("toString");
-    auto javaString = method(_javaPart);
-    return javaString->toStdString();
-  }
-
   // Properties
-  
+
 
   // Methods
   std::function<void()> JHybridViewModelTriggerPropertySpec::addListener(const std::function<void()>& onChanged) {
-    static const auto method = javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void::javaobject> /* onChanged */)>("addListener_cxx");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void::javaobject> /* onChanged */)>("addListener_cxx");
     auto __result = method(_javaPart, JFunc_void_cxx::fromCpp(onChanged));
     return [&]() -> std::function<void()> {
       if (__result->isInstanceOf(JFunc_void_cxx::javaClassStatic())) [[likely]] {
@@ -66,11 +60,11 @@ namespace margelo::nitro::rive {
     }();
   }
   void JHybridViewModelTriggerPropertySpec::trigger() {
-    static const auto method = javaClassStatic()->getMethod<void()>("trigger");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("trigger");
     method(_javaPart);
   }
   void JHybridViewModelTriggerPropertySpec::removeListeners() {
-    static const auto method = javaClassStatic()->getMethod<void()>("removeListeners");
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("removeListeners");
     method(_javaPart);
   }
 

--- a/nitrogen/generated/android/c++/JHybridViewModelTriggerPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelTriggerPropertySpec.hpp
@@ -40,19 +40,13 @@ namespace margelo::nitro::rive {
     }
 
   public:
-    size_t getExternalMemorySize() noexcept override;
-    bool equals(const std::shared_ptr<HybridObject>& other) override;
-    void dispose() noexcept override;
-    std::string toString() override;
-
-  public:
-    inline const jni::global_ref<JHybridViewModelTriggerPropertySpec::javaobject>& getJavaPart() const noexcept {
+    inline const jni::global_ref<JHybridViewModelTriggerPropertySpec::JavaPart>& getJavaPart() const noexcept {
       return _javaPart;
     }
 
   public:
     // Properties
-    
+
 
   public:
     // Methods
@@ -63,7 +57,7 @@ namespace margelo::nitro::rive {
   private:
     friend HybridBase;
     using HybridBase::HybridBase;
-    jni::global_ref<JHybridViewModelTriggerPropertySpec::javaobject> _javaPart;
+    jni::global_ref<JHybridViewModelTriggerPropertySpec::JavaPart> _javaPart;
   };
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JResolvedReferencedAsset.hpp
+++ b/nitrogen/generated/android/c++/JResolvedReferencedAsset.hpp
@@ -43,14 +43,14 @@ namespace margelo::nitro::rive {
       jni::local_ref<jni::JString> sourceAssetId = this->getFieldValue(fieldSourceAssetId);
       static const auto fieldPath = clazz->getField<jni::JString>("path");
       jni::local_ref<jni::JString> path = this->getFieldValue(fieldPath);
-      static const auto fieldImage = clazz->getField<JHybridRiveImageSpec::javaobject>("image");
-      jni::local_ref<JHybridRiveImageSpec::javaobject> image = this->getFieldValue(fieldImage);
+      static const auto fieldImage = clazz->getField<JHybridRiveImageSpec::JavaPart>("image");
+      jni::local_ref<JHybridRiveImageSpec::JavaPart> image = this->getFieldValue(fieldImage);
       return ResolvedReferencedAsset(
         sourceUrl != nullptr ? std::make_optional(sourceUrl->toStdString()) : std::nullopt,
         sourceAsset != nullptr ? std::make_optional(sourceAsset->toStdString()) : std::nullopt,
         sourceAssetId != nullptr ? std::make_optional(sourceAssetId->toStdString()) : std::nullopt,
         path != nullptr ? std::make_optional(path->toStdString()) : std::nullopt,
-        image != nullptr ? std::make_optional(image->cthis()->shared_cast<JHybridRiveImageSpec>()) : std::nullopt
+        image != nullptr ? std::make_optional(image->getJHybridRiveImageSpec()) : std::nullopt
       );
     }
 
@@ -60,7 +60,7 @@ namespace margelo::nitro::rive {
      */
     [[maybe_unused]]
     static jni::local_ref<JResolvedReferencedAsset::javaobject> fromCpp(const ResolvedReferencedAsset& value) {
-      using JSignature = JResolvedReferencedAsset(jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<JHybridRiveImageSpec::javaobject>);
+      using JSignature = JResolvedReferencedAsset(jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<JHybridRiveImageSpec::JavaPart>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(

--- a/nitrogen/generated/android/c++/JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName.cpp
+++ b/nitrogen/generated/android/c++/JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName.cpp
@@ -15,7 +15,7 @@ namespace margelo::nitro::rive {
     if (isInstanceOf(JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName_impl::First::javaClassStatic())) {
       // It's a `std::shared_ptr<HybridViewModelInstanceSpec>`
       auto jniValue = static_cast<const JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName_impl::First*>(this)->getValue();
-      return jniValue->cthis()->shared_cast<JHybridViewModelInstanceSpec>();
+      return jniValue->getJHybridViewModelInstanceSpec();
     } else if (isInstanceOf(JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName_impl::Second::javaClassStatic())) {
       // It's a `DataBindMode`
       auto jniValue = static_cast<const JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName_impl::Second*>(this)->getValue();

--- a/nitrogen/generated/android/c++/JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName.hpp
+++ b/nitrogen/generated/android/c++/JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName.hpp
@@ -31,8 +31,8 @@ namespace margelo::nitro::rive {
   public:
     static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/Variant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName;";
 
-    static jni::local_ref<JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName> create_0(jni::alias_ref<JHybridViewModelInstanceSpec::javaobject> value) {
-      static const auto method = javaClassStatic()->getStaticMethod<JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName(jni::alias_ref<JHybridViewModelInstanceSpec::javaobject>)>("create");
+    static jni::local_ref<JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName> create_0(jni::alias_ref<JHybridViewModelInstanceSpec::JavaPart> value) {
+      static const auto method = javaClassStatic()->getStaticMethod<JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName(jni::alias_ref<JHybridViewModelInstanceSpec::JavaPart>)>("create");
       return method(javaClassStatic(), value);
     }
     static jni::local_ref<JVariant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName> create_1(jni::alias_ref<JDataBindMode> value) {
@@ -61,8 +61,8 @@ namespace margelo::nitro::rive {
     public:
       static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/Variant_HybridViewModelInstanceSpec_DataBindMode_DataBindByName$First;";
     
-      [[nodiscard]] jni::local_ref<JHybridViewModelInstanceSpec::javaobject> getValue() const {
-        static const auto field = javaClassStatic()->getField<JHybridViewModelInstanceSpec::javaobject>("value");
+      [[nodiscard]] jni::local_ref<JHybridViewModelInstanceSpec::JavaPart> getValue() const {
+        static const auto field = javaClassStatic()->getField<JHybridViewModelInstanceSpec::JavaPart>("value");
         return getFieldValue(field);
       }
     };

--- a/nitrogen/generated/android/c++/views/JHybridRiveViewStateUpdater.cpp
+++ b/nitrogen/generated/android/c++/views/JHybridRiveViewStateUpdater.cpp
@@ -15,9 +15,9 @@ using namespace facebook;
 using ConcreteStateData = react::ConcreteState<HybridRiveViewState>;
 
 void JHybridRiveViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /* class */,
-                                           jni::alias_ref<JHybridRiveViewSpec::javaobject> javaView,
+                                           jni::alias_ref<JHybridRiveViewSpec::JavaPart> javaView,
                                            jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface) {
-  JHybridRiveViewSpec* view = javaView->cthis();
+  auto view = javaView->getJHybridRiveViewSpec();
 
   // Get concrete StateWrapperImpl from passed StateWrapper interface object
   jobject rawStateWrapper = stateWrapperInterface.get();
@@ -78,7 +78,7 @@ void JHybridRiveViewStateUpdater::updateViewProps(jni::alias_ref<jni::JClass> /*
     // hybridRef changed - call it with new this
     const auto& maybeFunc = props.hybridRef.value;
     if (maybeFunc.has_value()) {
-      std::shared_ptr<JHybridRiveViewSpec> shared = javaView->cthis()->shared_cast<JHybridRiveViewSpec>();
+      std::shared_ptr<JHybridRiveViewSpec> shared = javaView->getJHybridRiveViewSpec();
       maybeFunc.value()(shared);
     }
     // TODO: Set isDirty = false

--- a/nitrogen/generated/android/c++/views/JHybridRiveViewStateUpdater.hpp
+++ b/nitrogen/generated/android/c++/views/JHybridRiveViewStateUpdater.hpp
@@ -30,7 +30,7 @@ public:
 
 public:
   static void updateViewProps(jni::alias_ref<jni::JClass> /* class */,
-                              jni::alias_ref<JHybridRiveViewSpec::javaobject> view,
+                              jni::alias_ref<JHybridRiveViewSpec::JavaPart> view,
                               jni::alias_ref<JStateWrapper::javaobject> stateWrapperInterface);
 
 public:

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridBindableArtboardSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridBindableArtboardSpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridBindableArtboardSpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject BindableArtboard]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -49,7 +32,21 @@ abstract class HybridBindableArtboardSpec: HybridObject() {
   // Methods
   
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject BindableArtboard]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridBindableArtboardSpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridBindableArtboardSpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveFileFactorySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveFileFactorySpec.kt
@@ -26,25 +26,7 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridRiveFileFactorySpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject RiveFileFactory]"
-  }
-
   // Properties
-  
 
   // Methods
   @DoNotStrip
@@ -63,7 +45,21 @@ abstract class HybridRiveFileFactorySpec: HybridObject() {
   @Keep
   abstract fun fromBytes(bytes: ArrayBuffer, loadCdn: Boolean, referencedAssets: ReferencedAssetsType?): Promise<HybridRiveFileSpec>
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject RiveFileFactory]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridRiveFileFactorySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridRiveFileFactorySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveFileSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveFileSpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridRiveFileSpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject RiveFile]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -75,7 +58,21 @@ abstract class HybridRiveFileSpec: HybridObject() {
   @Keep
   abstract fun getBindableArtboard(name: String): HybridBindableArtboardSpec
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject RiveFile]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridRiveFileSpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridRiveFileSpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveImageFactorySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveImageFactorySpec.kt
@@ -26,25 +26,7 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridRiveImageFactorySpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject RiveImageFactory]"
-  }
-
   // Properties
-  
 
   // Methods
   @DoNotStrip
@@ -59,7 +41,21 @@ abstract class HybridRiveImageFactorySpec: HybridObject() {
   @Keep
   abstract fun loadFromBytesAsync(bytes: ArrayBuffer): Promise<HybridRiveImageSpec>
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject RiveImageFactory]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridRiveImageFactorySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridRiveImageFactorySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveImageSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveImageSpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridRiveImageSpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject RiveImage]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -49,7 +32,21 @@ abstract class HybridRiveImageSpec: HybridObject() {
   // Methods
   
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject RiveImage]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridRiveImageSpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridRiveImageSpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveRuntimeSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveRuntimeSpec.kt
@@ -25,23 +25,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridRiveRuntimeSpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject RiveRuntime]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -56,7 +39,21 @@ abstract class HybridRiveRuntimeSpec: HybridObject() {
   @Keep
   abstract fun initialize(): Promise<Unit>
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject RiveRuntime]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridRiveRuntimeSpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridRiveRuntimeSpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveSpec.kt
@@ -24,32 +24,28 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridRiveSpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject Rive]"
-  }
-
   // Properties
-  
 
   // Methods
   @DoNotStrip
   @Keep
   abstract fun multiply(a: Double, b: Double): Double
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject Rive]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridRiveSpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridRiveSpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveViewSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveViewSpec.kt
@@ -25,23 +25,6 @@ import com.margelo.nitro.views.HybridView
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridRiveViewSpec: HybridView() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject RiveView]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -175,7 +158,21 @@ abstract class HybridRiveViewSpec: HybridView() {
   @Keep
   abstract fun getTextRunValue(name: String, path: String?): String
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject RiveView]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridRiveViewSpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridRiveViewSpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelArtboardPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelArtboardPropertySpec.kt
@@ -24,32 +24,28 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelArtboardPropertySpec: HybridViewModelPropertySpec() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelArtboardProperty]"
-  }
-
   // Properties
-  
 
   // Methods
   @DoNotStrip
   @Keep
   abstract fun set(artboard: HybridBindableArtboardSpec?): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelArtboardProperty]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelArtboardPropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelArtboardPropertySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelBooleanPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelBooleanPropertySpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelBooleanPropertySpec: HybridViewModelPropertySpec() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelBooleanProperty]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -62,7 +45,21 @@ abstract class HybridViewModelBooleanPropertySpec: HybridViewModelPropertySpec()
   @Keep
   abstract fun removeListeners(): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelBooleanProperty]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelBooleanPropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelBooleanPropertySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelColorPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelColorPropertySpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelColorPropertySpec: HybridViewModelPropertySpec() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelColorProperty]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -62,7 +45,21 @@ abstract class HybridViewModelColorPropertySpec: HybridViewModelPropertySpec() {
   @Keep
   abstract fun removeListeners(): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelColorProperty]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelColorPropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelColorPropertySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelEnumPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelEnumPropertySpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelEnumPropertySpec: HybridViewModelPropertySpec() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelEnumProperty]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -62,7 +45,21 @@ abstract class HybridViewModelEnumPropertySpec: HybridViewModelPropertySpec() {
   @Keep
   abstract fun removeListeners(): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelEnumProperty]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelEnumPropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelEnumPropertySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelImagePropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelImagePropertySpec.kt
@@ -24,25 +24,7 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelImagePropertySpec: HybridViewModelPropertySpec() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelImageProperty]"
-  }
-
   // Properties
-  
 
   // Methods
   @DoNotStrip
@@ -62,7 +44,21 @@ abstract class HybridViewModelImagePropertySpec: HybridViewModelPropertySpec() {
   @Keep
   abstract fun removeListeners(): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelImageProperty]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelImagePropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelImagePropertySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelInstanceSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelInstanceSpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelInstanceSpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelInstance]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -91,7 +74,21 @@ abstract class HybridViewModelInstanceSpec: HybridObject() {
   @Keep
   abstract fun replaceViewModel(path: String, instance: HybridViewModelInstanceSpec): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelInstance]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelInstanceSpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelInstanceSpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelListPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelListPropertySpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelListPropertySpec: HybridViewModelPropertySpec() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelListProperty]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -84,7 +67,21 @@ abstract class HybridViewModelListPropertySpec: HybridViewModelPropertySpec() {
   @Keep
   abstract fun removeListeners(): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelListProperty]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelListPropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelListPropertySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelNumberPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelNumberPropertySpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelNumberPropertySpec: HybridViewModelPropertySpec() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelNumberProperty]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -62,7 +45,21 @@ abstract class HybridViewModelNumberPropertySpec: HybridViewModelPropertySpec() 
   @Keep
   abstract fun removeListeners(): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelNumberProperty]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelNumberPropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelNumberPropertySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelPropertySpec.kt
@@ -24,30 +24,26 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelPropertySpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
+  // Properties
 
-  init {
-    super.updateNative(mHybridData)
-  }
+  // Methods
+  
 
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
 
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {
     return "[HybridObject ViewModelProperty]"
   }
 
-  // Properties
-  
-
-  // Methods
-  
-
-  private external fun initHybrid(): HybridData
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelPropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelPropertySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelSpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelSpec: HybridObject() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModel]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -71,7 +54,21 @@ abstract class HybridViewModelSpec: HybridObject() {
   @Keep
   abstract fun createInstance(): HybridViewModelInstanceSpec?
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModel]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelSpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelSpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelStringPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelStringPropertySpec.kt
@@ -24,23 +24,6 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelStringPropertySpec: HybridViewModelPropertySpec() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelStringProperty]"
-  }
-
   // Properties
   @get:DoNotStrip
   @get:Keep
@@ -62,7 +45,21 @@ abstract class HybridViewModelStringPropertySpec: HybridViewModelPropertySpec() 
   @Keep
   abstract fun removeListeners(): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelStringProperty]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelStringPropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelStringPropertySpec"

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelTriggerPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelTriggerPropertySpec.kt
@@ -24,25 +24,7 @@ import com.margelo.nitro.core.HybridObject
   "LocalVariableName", "PropertyName", "PrivatePropertyName", "FunctionName"
 )
 abstract class HybridViewModelTriggerPropertySpec: HybridViewModelPropertySpec() {
-  @DoNotStrip
-  private var mHybridData: HybridData = initHybrid()
-
-  init {
-    super.updateNative(mHybridData)
-  }
-
-  override fun updateNative(hybridData: HybridData) {
-    mHybridData = hybridData
-    super.updateNative(hybridData)
-  }
-
-  // Default implementation of `HybridObject.toString()`
-  override fun toString(): String {
-    return "[HybridObject ViewModelTriggerProperty]"
-  }
-
   // Properties
-  
 
   // Methods
   abstract fun addListener(onChanged: () -> Unit): () -> Unit
@@ -62,7 +44,21 @@ abstract class HybridViewModelTriggerPropertySpec: HybridViewModelPropertySpec()
   @Keep
   abstract fun removeListeners(): Unit
 
-  private external fun initHybrid(): HybridData
+
+  // Default implementation of `HybridObject.toString()`
+  override fun toString(): String {
+    return "[HybridObject ViewModelTriggerProperty]"
+  }
+
+  // C++ backing class
+  @DoNotStrip
+  @Keep
+  protected open class CxxPart(javaPart: HybridViewModelTriggerPropertySpec): HybridObject.CxxPart(javaPart) {
+    external override fun initHybrid(): HybridData
+  }
+  override fun createCxxPart(): CxxPart {
+    return CxxPart(this)
+  }
 
   companion object {
     protected const val TAG = "HybridViewModelTriggerPropertySpec"

--- a/nitrogen/generated/android/riveOnLoad.cpp
+++ b/nitrogen/generated/android/riveOnLoad.cpp
@@ -10,11 +10,9 @@
 #endif
 
 #include "riveOnLoad.hpp"
-
 #include <jni.h>
 #include <fbjni/fbjni.h>
 #include <NitroModules/HybridObjectRegistry.hpp>
-
 #include "JHybridBindableArtboardSpec.hpp"
 #include "JHybridRiveSpec.hpp"
 #include "JHybridRiveFileSpec.hpp"
@@ -42,95 +40,139 @@
 #include "JHybridViewModelImagePropertySpec.hpp"
 #include "JHybridViewModelListPropertySpec.hpp"
 #include "JHybridViewModelArtboardPropertySpec.hpp"
-#include <NitroModules/DefaultConstructableObject.hpp>
 
 namespace margelo::nitro::rive {
 
 int initialize(JavaVM* vm) {
+  return facebook::jni::initialize(vm, []() {
+    ::margelo::nitro::rive::registerAllNatives();
+  });
+}
+
+struct JHybridRiveSpecImpl: public facebook::jni::JavaClass<JHybridRiveSpecImpl, JHybridRiveSpec::JavaPart> {
+  static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/Rive;";
+  static std::shared_ptr<JHybridRiveSpec> create() {
+    static auto constructorFn = javaClassStatic()->getConstructor<JHybridRiveSpecImpl::javaobject()>();
+    facebook::jni::local_ref<JHybridRiveSpec::JavaPart> javaPart = javaClassStatic()->newObject(constructorFn);
+    return javaPart->getJHybridRiveSpec();
+  }
+};
+
+struct JHybridRiveFileFactorySpecImpl: public facebook::jni::JavaClass<JHybridRiveFileFactorySpecImpl, JHybridRiveFileFactorySpec::JavaPart> {
+  static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveFileFactory;";
+  static std::shared_ptr<JHybridRiveFileFactorySpec> create() {
+    static auto constructorFn = javaClassStatic()->getConstructor<JHybridRiveFileFactorySpecImpl::javaobject()>();
+    facebook::jni::local_ref<JHybridRiveFileFactorySpec::JavaPart> javaPart = javaClassStatic()->newObject(constructorFn);
+    return javaPart->getJHybridRiveFileFactorySpec();
+  }
+};
+
+struct JHybridRiveFileSpecImpl: public facebook::jni::JavaClass<JHybridRiveFileSpecImpl, JHybridRiveFileSpec::JavaPart> {
+  static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveFile;";
+  static std::shared_ptr<JHybridRiveFileSpec> create() {
+    static auto constructorFn = javaClassStatic()->getConstructor<JHybridRiveFileSpecImpl::javaobject()>();
+    facebook::jni::local_ref<JHybridRiveFileSpec::JavaPart> javaPart = javaClassStatic()->newObject(constructorFn);
+    return javaPart->getJHybridRiveFileSpec();
+  }
+};
+
+struct JHybridRiveViewSpecImpl: public facebook::jni::JavaClass<JHybridRiveViewSpecImpl, JHybridRiveViewSpec::JavaPart> {
+  static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveView;";
+  static std::shared_ptr<JHybridRiveViewSpec> create() {
+    static auto constructorFn = javaClassStatic()->getConstructor<JHybridRiveViewSpecImpl::javaobject()>();
+    facebook::jni::local_ref<JHybridRiveViewSpec::JavaPart> javaPart = javaClassStatic()->newObject(constructorFn);
+    return javaPart->getJHybridRiveViewSpec();
+  }
+};
+
+struct JHybridRiveImageFactorySpecImpl: public facebook::jni::JavaClass<JHybridRiveImageFactorySpecImpl, JHybridRiveImageFactorySpec::JavaPart> {
+  static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveImageFactory;";
+  static std::shared_ptr<JHybridRiveImageFactorySpec> create() {
+    static auto constructorFn = javaClassStatic()->getConstructor<JHybridRiveImageFactorySpecImpl::javaobject()>();
+    facebook::jni::local_ref<JHybridRiveImageFactorySpec::JavaPart> javaPart = javaClassStatic()->newObject(constructorFn);
+    return javaPart->getJHybridRiveImageFactorySpec();
+  }
+};
+
+struct JHybridRiveRuntimeSpecImpl: public facebook::jni::JavaClass<JHybridRiveRuntimeSpecImpl, JHybridRiveRuntimeSpec::JavaPart> {
+  static auto constexpr kJavaDescriptor = "Lcom/margelo/nitro/rive/HybridRiveRuntime;";
+  static std::shared_ptr<JHybridRiveRuntimeSpec> create() {
+    static auto constructorFn = javaClassStatic()->getConstructor<JHybridRiveRuntimeSpecImpl::javaobject()>();
+    facebook::jni::local_ref<JHybridRiveRuntimeSpec::JavaPart> javaPart = javaClassStatic()->newObject(constructorFn);
+    return javaPart->getJHybridRiveRuntimeSpec();
+  }
+};
+
+void registerAllNatives() {
   using namespace margelo::nitro;
   using namespace margelo::nitro::rive;
-  using namespace facebook;
 
-  return facebook::jni::initialize(vm, [] {
-    // Register native JNI methods
-    margelo::nitro::rive::JHybridBindableArtboardSpec::registerNatives();
-    margelo::nitro::rive::JHybridRiveSpec::registerNatives();
-    margelo::nitro::rive::JHybridRiveFileSpec::registerNatives();
-    margelo::nitro::rive::JHybridRiveFileFactorySpec::registerNatives();
-    margelo::nitro::rive::JHybridRiveImageSpec::registerNatives();
-    margelo::nitro::rive::JHybridRiveImageFactorySpec::registerNatives();
-    margelo::nitro::rive::JHybridRiveRuntimeSpec::registerNatives();
-    margelo::nitro::rive::JHybridRiveViewSpec::registerNatives();
-    margelo::nitro::rive::JFunc_void_RiveError_cxx::registerNatives();
-    margelo::nitro::rive::JFunc_void_UnifiedRiveEvent_cxx::registerNatives();
-    margelo::nitro::rive::views::JHybridRiveViewStateUpdater::registerNatives();
-    margelo::nitro::rive::JHybridViewModelSpec::registerNatives();
-    margelo::nitro::rive::JHybridViewModelInstanceSpec::registerNatives();
-    margelo::nitro::rive::JHybridViewModelPropertySpec::registerNatives();
-    margelo::nitro::rive::JHybridViewModelNumberPropertySpec::registerNatives();
-    margelo::nitro::rive::JFunc_void_cxx::registerNatives();
-    margelo::nitro::rive::JFunc_void_double_cxx::registerNatives();
-    margelo::nitro::rive::JHybridViewModelStringPropertySpec::registerNatives();
-    margelo::nitro::rive::JFunc_void_std__string_cxx::registerNatives();
-    margelo::nitro::rive::JHybridViewModelBooleanPropertySpec::registerNatives();
-    margelo::nitro::rive::JFunc_void_bool_cxx::registerNatives();
-    margelo::nitro::rive::JHybridViewModelColorPropertySpec::registerNatives();
-    margelo::nitro::rive::JHybridViewModelEnumPropertySpec::registerNatives();
-    margelo::nitro::rive::JHybridViewModelTriggerPropertySpec::registerNatives();
-    margelo::nitro::rive::JHybridViewModelImagePropertySpec::registerNatives();
-    margelo::nitro::rive::JHybridViewModelListPropertySpec::registerNatives();
-    margelo::nitro::rive::JHybridViewModelArtboardPropertySpec::registerNatives();
+  // Register native JNI methods
+  margelo::nitro::rive::JHybridBindableArtboardSpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridRiveSpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridRiveFileSpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridRiveFileFactorySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridRiveImageSpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridRiveImageFactorySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridRiveRuntimeSpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridRiveViewSpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelSpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelInstanceSpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelPropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelNumberPropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelStringPropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelBooleanPropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelColorPropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelEnumPropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelTriggerPropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelImagePropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelListPropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JHybridViewModelArtboardPropertySpec::CxxPart::registerNatives();
+  margelo::nitro::rive::JFunc_void_RiveError_cxx::registerNatives();
+  margelo::nitro::rive::JFunc_void_UnifiedRiveEvent_cxx::registerNatives();
+  margelo::nitro::rive::JFunc_void_cxx::registerNatives();
+  margelo::nitro::rive::JFunc_void_double_cxx::registerNatives();
+  margelo::nitro::rive::JFunc_void_std__string_cxx::registerNatives();
+  margelo::nitro::rive::JFunc_void_bool_cxx::registerNatives();
+  margelo::nitro::rive::views::JHybridRiveViewStateUpdater::registerNatives();
 
-    // Register Nitro Hybrid Objects
-    HybridObjectRegistry::registerHybridObjectConstructor(
-      "Rive",
-      []() -> std::shared_ptr<HybridObject> {
-        static DefaultConstructableObject<JHybridRiveSpec::javaobject> object("com/margelo/nitro/rive/Rive");
-        auto instance = object.create();
-        return instance->cthis()->shared();
-      }
-    );
-    HybridObjectRegistry::registerHybridObjectConstructor(
-      "RiveFileFactory",
-      []() -> std::shared_ptr<HybridObject> {
-        static DefaultConstructableObject<JHybridRiveFileFactorySpec::javaobject> object("com/margelo/nitro/rive/HybridRiveFileFactory");
-        auto instance = object.create();
-        return instance->cthis()->shared();
-      }
-    );
-    HybridObjectRegistry::registerHybridObjectConstructor(
-      "RiveFile",
-      []() -> std::shared_ptr<HybridObject> {
-        static DefaultConstructableObject<JHybridRiveFileSpec::javaobject> object("com/margelo/nitro/rive/HybridRiveFile");
-        auto instance = object.create();
-        return instance->cthis()->shared();
-      }
-    );
-    HybridObjectRegistry::registerHybridObjectConstructor(
-      "RiveView",
-      []() -> std::shared_ptr<HybridObject> {
-        static DefaultConstructableObject<JHybridRiveViewSpec::javaobject> object("com/margelo/nitro/rive/HybridRiveView");
-        auto instance = object.create();
-        return instance->cthis()->shared();
-      }
-    );
-    HybridObjectRegistry::registerHybridObjectConstructor(
-      "RiveImageFactory",
-      []() -> std::shared_ptr<HybridObject> {
-        static DefaultConstructableObject<JHybridRiveImageFactorySpec::javaobject> object("com/margelo/nitro/rive/HybridRiveImageFactory");
-        auto instance = object.create();
-        return instance->cthis()->shared();
-      }
-    );
-    HybridObjectRegistry::registerHybridObjectConstructor(
-      "RiveRuntime",
-      []() -> std::shared_ptr<HybridObject> {
-        static DefaultConstructableObject<JHybridRiveRuntimeSpec::javaobject> object("com/margelo/nitro/rive/HybridRiveRuntime");
-        auto instance = object.create();
-        return instance->cthis()->shared();
-      }
-    );
-  });
+  // Register Nitro Hybrid Objects
+  HybridObjectRegistry::registerHybridObjectConstructor(
+    "Rive",
+    []() -> std::shared_ptr<HybridObject> {
+      return JHybridRiveSpecImpl::create();
+    }
+  );
+  HybridObjectRegistry::registerHybridObjectConstructor(
+    "RiveFileFactory",
+    []() -> std::shared_ptr<HybridObject> {
+      return JHybridRiveFileFactorySpecImpl::create();
+    }
+  );
+  HybridObjectRegistry::registerHybridObjectConstructor(
+    "RiveFile",
+    []() -> std::shared_ptr<HybridObject> {
+      return JHybridRiveFileSpecImpl::create();
+    }
+  );
+  HybridObjectRegistry::registerHybridObjectConstructor(
+    "RiveView",
+    []() -> std::shared_ptr<HybridObject> {
+      return JHybridRiveViewSpecImpl::create();
+    }
+  );
+  HybridObjectRegistry::registerHybridObjectConstructor(
+    "RiveImageFactory",
+    []() -> std::shared_ptr<HybridObject> {
+      return JHybridRiveImageFactorySpecImpl::create();
+    }
+  );
+  HybridObjectRegistry::registerHybridObjectConstructor(
+    "RiveRuntime",
+    []() -> std::shared_ptr<HybridObject> {
+      return JHybridRiveRuntimeSpecImpl::create();
+    }
+  );
 }
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/riveOnLoad.hpp
+++ b/nitrogen/generated/android/riveOnLoad.hpp
@@ -6,20 +6,29 @@
 ///
 
 #include <jni.h>
+#include <functional>
 #include <NitroModules/NitroDefines.hpp>
 
 namespace margelo::nitro::rive {
 
+  [[deprecated("Use registerNatives() instead.")]]
+  int initialize(JavaVM* vm);
+
   /**
-   * Initializes the native (C++) part of rive, and autolinks all Hybrid Objects.
-   * Call this in your `JNI_OnLoad` function (probably inside `cpp-adapter.cpp`).
+   * Register the native (C++) part of rive, and autolinks all Hybrid Objects.
+   * Call this in your `JNI_OnLoad` function (probably inside `cpp-adapter.cpp`),
+   * inside a `facebook::jni::initialize(vm, ...)` call.
    * Example:
    * ```cpp (cpp-adapter.cpp)
    * JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
-   *   return margelo::nitro::rive::initialize(vm);
+   *   return facebook::jni::initialize(vm, []() {
+   *     // register all rive HybridObjects
+   *     margelo::nitro::rive::registerAllNatives();
+   *     // any other custom registrations go here.
+   *   });
    * }
    * ```
    */
-  int initialize(JavaVM* vm);
+  void registerAllNatives();
 
 } // namespace margelo::nitro::rive


### PR DESCRIPTION
## Summary

- Updates all nitrogen-generated Android code (68 files) to use the newer Nitro Modules API with `CxxPart`/`JavaPart` inner classes instead of the legacy `HybridClass` pattern
- Fixes Android build compatibility with recent versions of `react-native-nitro-modules` (0.35.0)
- Adds `registerAllNatives()` entry point and deprecates the old `initialize()` function

## Changes

### Kotlin (20 files)
All `HybridXxxSpec.kt` files updated:
- Removed manual `HybridData`/`initHybrid()`/`updateNative()` boilerplate
- Added `CxxPart` inner class and `createCxxPart()` override

### C++ Headers (20 files)
All `JHybridXxxSpec.hpp` files updated:
- Migrated from `jni::HybridClass<JHybridXxxSpec, JHybridObject>` to `JavaPart`/`CxxPart` struct pattern
- Updated constructor to accept `JavaPart` reference
- Removed `getExternalMemorySize()`, `equals()`, `dispose()`, `toString()` (now handled by base class)
- Changed `_javaPart` type from `javaobject` to `JavaPart`

### C++ Implementations (20 files)
All `JHybridXxxSpec.cpp` files updated:
- Added `JavaPart::getJHybridXxxSpec()` factory method
- Added `CxxPart::initHybrid()`, `CxxPart::createHybridObject()`, `CxxPart::registerNatives()`
- Replaced `javaClassStatic()->` with `_javaPart->javaClassStatic()->`

### Other files (8 files)
- `JVariant_*` and `JResolvedReferencedAsset`: Updated `::javaobject` references to `::JavaPart`
- `JHybridRiveViewStateUpdater`: Updated view reference pattern for new API
- `riveOnLoad.hpp/cpp`: Added `registerAllNatives()`, deprecate `initialize()`, added `Impl` factory structs
- `cpp-adapter.cpp`: Use `facebook::jni::initialize` with `registerAllNatives()`

## Context

The current nitrogen-generated code uses an older Nitro Modules pattern that is incompatible with `react-native-nitro-modules` v0.22+. The new `CxxPart`/`JavaPart` pattern is the current standard used by the nitrogen code generator. This can alternatively be fixed by re-running the nitrogen code generator against the current version.

## Test plan

- [ ] Verify Android build succeeds
- [ ] Test Rive animations render correctly on Android
- [ ] Verify iOS is unaffected (no iOS changes)
- [ ] Test ViewModel data binding functionality