### PR TITLE
fix(android): use device density for Fit.Layout in experimental backend

### DIFF
--- a/android/src/new/java/com/margelo/nitro/rive/HybridRiveView.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridRiveView.kt
@@ -241,7 +241,7 @@ class HybridRiveView(val context: ThemedReactContext) : HybridRiveViewSpec() {
       Fit.FITHEIGHT -> RiveFit.FitHeight()
       Fit.NONE -> RiveFit.None()
       Fit.SCALEDOWN -> RiveFit.ScaleDown()
-      Fit.LAYOUT -> RiveFit.Layout(scaleFactor = layoutScaleFactor ?: 1f)
+      Fit.LAYOUT -> RiveFit.Layout(scaleFactor = layoutScaleFactor ?: context.resources.displayMetrics.density)
     }
   }
 


### PR DESCRIPTION
Port of #209 fix to the experimental backend. The legacy backend defaulted `layoutScaleFactor` to `resources.displayMetrics.density` when unset, but the experimental backend defaulted to `1f`, causing the artboard to render at pixel dimensions instead of dp.