### PR TITLE
fix: bump rive-ios to 6.18.2 and rive-android to 11.4.0

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1754,7 +1754,7 @@ PODS:
     - React-logger (= 0.79.2)
     - React-perflogger (= 0.79.2)
     - React-utils (= 0.79.2)
-  - RiveRuntime (6.18.0)
+  - RiveRuntime (6.18.2)
   - RNCAsyncStorage (2.2.0):
     - DoubleConversion
     - glog
@@ -1904,7 +1904,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - RNWorklets
     - Yoga
-  - RNRive (0.3.2):
+  - RNRive (0.4.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1928,7 +1928,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RiveRuntime (= 6.18.0)
+    - RiveRuntime (= 6.18.2)
     - Yoga
   - RNScreens (4.18.0):
     - DoubleConversion
@@ -2379,12 +2379,12 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
   ReactCodegen: c63eda03ba1d94353fb97b031fc84f75a0d125ba
   ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
-  RiveRuntime: 67df68cb59eeee7334a6c6656230393986858ac3
+  RiveRuntime: 55c7a7badd9a8389d20fc8a75b7c6accc851b69a
   RNCAsyncStorage: a1c8cc8a99c32de1244a9cf707bf9d83d0de0f71
   RNCPicker: 28c076ae12a1056269ec0305fe35fac3086c477d
   RNGestureHandler: 6b39f4e43e4b3a0fb86de9531d090ff205a011d5
   RNReanimated: 66b68ebe3baf7ec9e716bd059d700726f250d344
-  RNRive: 2f0c6b599d74043cbc97ed60d705445f911a1c3f
+  RNRive: c02b3545abcf477d074945c5103f9f4bc9d8d672
   RNScreens: f38464ec1e83bda5820c3b05ccf4908e3841c5cc
   RNWorklets: b1faafefb82d9f29c4018404a0fb33974b494a7b
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
   "runtimeVersions": {
-    "ios": "6.18.0",
-    "android": "11.3.1"
+    "ios": "6.18.2",
+    "android": "11.4.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Bump native Rive SDKs: rive-ios 6.18.0 → 6.18.2, rive-android 11.3.1 → 11.4.0.

Note: rive-ios 6.18.3 is tagged on GitHub but not yet published to CocoaPods, so using 6.18.2.

### rive-ios 6.18.1–6.18.2
- fix(renderer): gamma correction fix
- fix(runtime): databind state machine transition duration
- fix(runtime): nullptr check for ConditionComparison during transition
- fix(runtime): memory leak with listeners on scripted VM properties
- fix(editor/runtime): honor path effect shape for inner vector feathering
- feat: expose view model name from view model instance
- feat: image fit & alignment when parented by layout

### rive-android 11.3.2–11.4.0
- fix(android): keep RenderTarget alive for deferred draw callbacks
- fix(Vulkan): fix saturation blend mode on some devices
- fix(runtime): databind state machine transition duration
- fix(runtime): nullptr check for ConditionComparison during transition
- fix(runtime): memory leak with listeners on scripted VM properties
- feat: component based conditions support
- feat: single/multiline support in TextInput and improved scrolling
- feat: image fit & alignment when parented by layout