### PR TITLE
fix(iOS): dispatch completion to main thread in handlePreloadedImage

### DIFF
--- a/ios/ReferencedAssetLoader.swift
+++ b/ios/ReferencedAssetLoader.swift
@@ -81,12 +81,14 @@ final class ReferencedAssetLoader {
     guard let imageAsset = asset as? RiveImageAsset,
       let hybridImage = image as? HybridRiveImage
     else {
-      completion()
+      DispatchQueue.main.async { completion() }
       return
     }
 
-    imageAsset.renderImage(hybridImage.renderImage)
-    completion()
+    DispatchQueue.main.async {
+      imageAsset.renderImage(hybridImage.renderImage)
+      completion()
+    }
   }
 
   private func loadAssetInternal(


### PR DESCRIPTION
Fixes #221

`handlePreloadedImage` was calling `completion()` synchronously on the Rive C++ runtime's background import queue, but `completion` triggers `releaseFile()` which asserts main thread via `dispatchPrecondition`. Every other asset path in `ReferencedAssetLoader` already dispatches to main before calling `completion()` — this was the only one missing it.

### Crash stack (reproduced locally)
```
_assertionFailure
ReferencedAssetLoader.handlePreloadedImage(_:asset:completion:)
ReferencedAssetLoader.loadAssetInternal(source:asset:factory:completion:)
closure #1 in ReferencedAssetLoader.createCustomLoader(...)
rive::File::import(...)  ← background queue
HybridRiveFileFactory.genericFrom(...)  ← DispatchQueue.global(.userInitiated)
```

Reproduced using the Out-of-Band Assets (Suspense) exerciser which calls `RiveImages.loadFromURLAsync` and passes the preloaded `RiveImage` via `referencedAssets`.