### PR TITLE
fix(Android): prevent data binding blink on mount

### DIFF
--- a/android/src/main/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rive/RiveReactNativeView.kt
@@ -107,20 +107,24 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
       ?: resources.displayMetrics.density
 
     if (reload) {
-      val hasDataBinding = when (config.bindData) {
-        is BindData.None -> false
-        is BindData.Auto -> false
-        is BindData.Instance, is BindData.ByName -> true
-      }
+      val hasDataBinding = config.bindData !is BindData.None
       riveAnimationView?.setRiveFile(
         config.riveFile,
         artboardName = config.artboardName,
         stateMachineName = config.stateMachineName,
-        autoplay = config.autoPlay,
-        autoBind = hasDataBinding,
+        autoplay = false,
+        autoBind = false,
         alignment = config.alignment,
         fit = config.fit
       )
+
+      if (config.autoPlay) {
+        // Create the state machine by calling play(). When data binding is needed,
+        // use settleInitialState=false so the SM isn't advanced before we bind the
+        // correct ViewModel — the first Choreographer frame will advance it with
+        // the correct values already bound.
+        riveAnimationView?.play(settleInitialState = !hasDataBinding)
+      }
       _activeStateMachineName = getSafeStateMachineName()
     } else {
       riveAnimationView?.alignment = config.alignment
@@ -129,6 +133,10 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
 
     if (dataBindingChanged || initialUpdate || reload) {
       applyDataBinding(config.bindData)
+    }
+
+    if (config.autoPlay && !reload) {
+      play()
     }
 
     viewReadyDeferred.complete(true)

--- a/ios/ReferencedAssetLoader.swift
+++ b/ios/ReferencedAssetLoader.swift
@@ -81,12 +81,16 @@ final class ReferencedAssetLoader {
     guard let imageAsset = asset as? RiveImageAsset,
       let hybridImage = image as? HybridRiveImage
     else {
-      completion()
+      DispatchQueue.main.async { completion() }
       return
     }
 
     imageAsset.renderImage(hybridImage.renderImage)
-    completion()
+    if Thread.isMainThread {
+      completion()
+    } else {
+      DispatchQueue.main.async { completion() }
+    }
   }
 
   private func loadAssetInternal(


### PR DESCRIPTION
Fixes #203

When data binding is active, the state machine was being advanced (`settleInitialState`) before the ViewModel was bound, causing a single frame with wrong default values (visible as a border animation flash on mount).

Fix: call `play(settleInitialState=false)` to create the SM without advancing it, then bind the ViewModel, so the first Choreographer frame advances with correct values already bound.

https://github.com/user-attachments/assets/placeholder-before

https://github.com/user-attachments/assets/placeholder-after