### PR TITLE
fix: prevent crash when React Fabric diffs props on disposed HybridObject

### DIFF
--- a/src/core/callDispose.ts
+++ b/src/core/callDispose.ts
@@ -16,7 +16,11 @@ interface Disposable {
  * Also handles https://github.com/mrousavy/nitro/issues/1083
  */
 export function callDispose(obj: Disposable): void {
+  // Override inherited (prototype) properties — these are the Nitro HybridObject
+  // getters that would throw after dispose. Own properties are left alone since
+  // they are plain JS values, not native getters.
   for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) continue;
     if (key === '__type' || key === 'dispose') continue;
     try {
       Object.defineProperty(obj, key, {

--- a/src/core/callDispose.ts
+++ b/src/core/callDispose.ts
@@ -4,8 +4,41 @@ interface Disposable {
   dispose(): void;
 }
 
-/** Safely calls dispose(), ignoring errors from https://github.com/mrousavy/nitro/issues/1083 */
+/**
+ * Safely disposes a Nitro HybridObject.
+ *
+ * Before calling dispose(), overrides all JS-visible properties with undefined
+ * so that React Fabric can safely diff old props without crashing. Without this,
+ * Fabric's cloneNodeWithNewProps reads properties (e.g. toString, artboardNames)
+ * from the disposed object whose NativeState is already null, causing:
+ *   "Cannot get hybrid property ... - `this`'s `NativeState` is `null`"
+ *
+ * Also handles https://github.com/mrousavy/nitro/issues/1083
+ */
 export function callDispose(obj: Disposable): void {
+  for (const key in obj) {
+    if (key === '__type' || key === 'dispose') continue;
+    try {
+      Object.defineProperty(obj, key, {
+        value: undefined,
+        enumerable: false,
+        configurable: true,
+      });
+    } catch (_) {
+      // non-configurable — skip
+    }
+  }
+
+  try {
+    Object.defineProperty(obj, 'toString', {
+      value: () => '[disposed HybridObject]',
+      enumerable: false,
+      configurable: true,
+    });
+  } catch (_) {
+    // skip
+  }
+
   try {
     obj.dispose();
   } catch (error) {


### PR DESCRIPTION
Calling `dispose()` on a HybridObject that's currently a prop on a HybridView crashes on RN 0.83 (React 19 / Fabric). React Fabric's `cloneNodeWithNewProps` reads properties from the old prop value after `dispose()` has set NativeState to null, causing `"Cannot get hybrid property ... NativeState is null"`.

This overrides JS-visible properties with `undefined` before calling `dispose()`, so Fabric reads harmless values instead of hitting the native getter.

Reproducer: rapidly switch the `file` prop on `RiveView` (e.g. via a `FileSwitcher` exerciser that cycles through multiple .riv files with 50ms intervals).

<details>
<summary>FileSwitcher exerciser (not included in this PR)</summary>

```tsx
// example/src/exercisers/FileSwitcher.tsx
/**
 * File Switcher Exerciser
 *
 * Rapidly switch between .riv files with different fit modes to test for
 * crashes related to dispose/render races.
 *
 * Reproduces "Should not already be working" crash seen on RN 0.83.
 */

import { useState } from 'react';
import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
import { Fit, RiveView, useRiveFile } from '@rive-app/react-native';
import { type Metadata } from '../shared/metadata';

const FILES = [
  {
    label: 'layout_test',
    source: require('../../assets/rive/layout_test.riv'),
  },
  { label: 'inputglow', source: require('../../assets/rive/inputglow.riv') },
  {
    label: 'GradientBorder',
    source: require('../../assets/rive/GradientBorder.riv'),
  },
  {
    label: 'layouts_demo',
    source: require('../../assets/rive/layouts_demo.riv'),
  },
  {
    label: 'bouncing_ball',
    source: require('../../assets/rive/bouncing_ball.riv'),
  },
  { label: 'counter', source: require('../../assets/rive/counter.riv') },
  { label: 'rating', source: require('../../assets/rive/rating.riv') },
] as const;

const FITS = [
  { label: 'Layout', value: Fit.Layout },
  { label: 'Contain', value: Fit.Contain },
  { label: 'Cover', value: Fit.Cover },
  { label: 'Fill', value: Fit.Fill },
] as const;

const SIZES = [
  { label: 'full x 150', width: '100%' as const, height: 150 },
  { label: 'full x 80', width: '100%' as const, height: 80 },
  { label: '200 x 120', width: 200, height: 120 },
];

function RiveBox({
  source,
  fit,
  height,
  width,
}: {
  source: number;
  fit: Fit;
  height: number;
  width: number | string;
}) {
  const { riveFile } = useRiveFile(source);

  return (
    <View style={[styles.riveBox, { height, width }]}>
      {riveFile && (
        <RiveView file={riveFile} autoPlay fit={fit} style={{ flex: 1 }} />
      )}
    </View>
  );
}

function Chip({
  label,
  selected,
  onPress,
}: {
  label: string;
  selected: boolean;
  onPress: () => void;
}) {
  return (
    <Pressable
      onPress={onPress}
      style={[styles.chip, selected && styles.chipSelected]}
    >
      <Text style={[styles.chipText, selected && styles.chipTextSelected]}>
        {label}
      </Text>
    </Pressable>
  );
}

export const metadata: Metadata = {
  name: 'File Switcher',
  description: 'Rapidly switch files/fits to test dispose/render race crashes',
};

export default function FileSwitcher() {
  const [fileIdx, setFileIdx] = useState(0);
  const [fitIdx, setFitIdx] = useState(0);

  const file = FILES[fileIdx]!;
  const fit = FITS[fitIdx]!;

  return (
    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
      <Text style={styles.section}>File</Text>
      <View style={styles.chips}>
        {FILES.map((f, i) => (
          <Chip
            key={f.label}
            label={f.label}
            selected={i === fileIdx}
            onPress={() => setFileIdx(i)}
          />
        ))}
      </View>

      <Text style={styles.section}>Fit</Text>
      <View style={styles.chips}>
        {FITS.map((f, i) => (
          <Chip
            key={f.label}
            label={f.label}
            selected={i === fitIdx}
            onPress={() => setFitIdx(i)}
          />
        ))}
      </View>

      <Text style={styles.section}>
        {file.label} — Fit.{fit.label}
      </Text>
      {SIZES.map((size) => (
        <View key={size.label} style={styles.item}>
          <Text style={styles.label}>{size.label}</Text>
          <RiveBox
            source={file.source}
            fit={fit.value}
            height={size.height}
            width={size.width}
          />
        </View>
      ))}
    </ScrollView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#0c1027',
  },
  content: {
    padding: 20,
    paddingBottom: 60,
  },
  section: {
    color: '#fff',
    fontSize: 16,
    fontWeight: 'bold',
    marginTop: 16,
    marginBottom: 8,
  },
  chips: {
    flexDirection: 'row',
    flexWrap: 'wrap',
    gap: 8,
  },
  chip: {
    paddingHorizontal: 12,
    paddingVertical: 6,
    borderRadius: 16,
    borderWidth: 1,
    borderColor: '#555',
  },
  chipSelected: {
    backgroundColor: '#4f6ef7',
    borderColor: '#4f6ef7',
  },
  chipText: {
    color: '#999',
    fontSize: 13,
  },
  chipTextSelected: {
    color: '#fff',
  },
  item: {
    marginBottom: 16,
  },
  label: {
    color: '#999',
    fontSize: 12,
    marginBottom: 4,
  },
  riveBox: {
    borderWidth: 1,
    borderColor: 'red',
  },
});
```

</details>

Upstream Nitro issue: https://github.com/mrousavy/nitro/issues/1296