### PR TITLE
feat: add RiveLog.setLogLevel() to filter log output

### DIFF
--- a/android/src/main/java/com/margelo/nitro/rive/HybridRiveLogger.kt
+++ b/android/src/main/java/com/margelo/nitro/rive/HybridRiveLogger.kt
@@ -13,4 +13,10 @@ class HybridRiveLogger : HybridRiveLoggerSpec() {
     override fun resetHandler() {
         RiveLog.handler = null
     }
+
+    override fun setLogLevel(level: String) {
+        val parsed = RiveLogLevel.fromString(level)
+            ?: throw RuntimeException("Invalid log level '$level'. Use: debug, info, warn, error")
+        RiveLog.minLevel = parsed
+    }
 }

--- a/android/src/main/java/com/margelo/nitro/rive/RiveLog.kt
+++ b/android/src/main/java/com/margelo/nitro/rive/RiveLog.kt
@@ -2,22 +2,45 @@ package com.margelo.nitro.rive
 
 import android.util.Log
 
+enum class RiveLogLevel(val priority: Int) {
+    DEBUG(0),
+    INFO(1),
+    WARN(2),
+    ERROR(3),
+    ;
+
+  companion object {
+        fun fromString(level: String): RiveLogLevel? = when (level) {
+            "debug" -> DEBUG
+            "info" -> INFO
+            "warn" -> WARN
+            "error" -> ERROR
+            else -> null
+        }
+    }
+}
+
 object RiveLog {
     var handler: ((String, String, String) -> Unit)? = null
+    var minLevel: RiveLogLevel = RiveLogLevel.WARN
 
     fun e(tag: String, message: String) {
+        if (RiveLogLevel.ERROR.priority < minLevel.priority) return
         handler?.invoke("error", tag, message) ?: Log.e(tag, message)
     }
 
     fun w(tag: String, message: String) {
+        if (RiveLogLevel.WARN.priority < minLevel.priority) return
         handler?.invoke("warn", tag, message) ?: Log.w(tag, message)
     }
 
     fun i(tag: String, message: String) {
+        if (RiveLogLevel.INFO.priority < minLevel.priority) return
         handler?.invoke("info", tag, message) ?: Log.i(tag, message)
     }
 
     fun d(tag: String, message: String) {
+        if (RiveLogLevel.DEBUG.priority < minLevel.priority) return
         handler?.invoke("debug", tag, message) ?: Log.d(tag, message)
     }
 }

--- a/ios/HybridRiveLogger.swift
+++ b/ios/HybridRiveLogger.swift
@@ -8,4 +8,11 @@ class HybridRiveLogger: HybridRiveLoggerSpec {
     func resetHandler() throws {
         RiveLog.handler = nil
     }
+
+    func setLogLevel(level: String) throws {
+        guard let parsed = RiveLogLevel(string: level) else {
+            throw RuntimeError.error(withMessage: "Invalid log level '\(level)'. Use: debug, info, warn, error")
+        }
+        RiveLog.minLevel = parsed
+    }
 }

--- a/ios/RiveLog.swift
+++ b/ios/RiveLog.swift
@@ -1,7 +1,30 @@
+enum RiveLogLevel: Int, Comparable {
+    case debug = 0
+    case info = 1
+    case warn = 2
+    case error = 3
+
+    static func < (lhs: RiveLogLevel, rhs: RiveLogLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    init?(string: String) {
+        switch string {
+        case "debug": self = .debug
+        case "info": self = .info
+        case "warn": self = .warn
+        case "error": self = .error
+        default: return nil
+        }
+    }
+}
+
 enum RiveLog {
     static var handler: ((String, String, String) -> Void)?
+    static var minLevel: RiveLogLevel = .warn
 
     static func e(_ tag: String, _ message: String) {
+        guard .error >= minLevel else { return }
         if let handler = handler {
             handler("error", tag, message)
         } else {
@@ -10,6 +33,7 @@ enum RiveLog {
     }
 
     static func w(_ tag: String, _ message: String) {
+        guard .warn >= minLevel else { return }
         if let handler = handler {
             handler("warn", tag, message)
         } else {
@@ -18,6 +42,7 @@ enum RiveLog {
     }
 
     static func i(_ tag: String, _ message: String) {
+        guard .info >= minLevel else { return }
         if let handler = handler {
             handler("info", tag, message)
         } else {
@@ -26,6 +51,7 @@ enum RiveLog {
     }
 
     static func d(_ tag: String, _ message: String) {
+        guard .debug >= minLevel else { return }
         if let handler = handler {
             handler("debug", tag, message)
         } else {

--- a/nitrogen/generated/android/c++/JHybridRiveLoggerSpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridRiveLoggerSpec.cpp
@@ -55,5 +55,9 @@ namespace margelo::nitro::rive {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void()>("resetHandler");
     method(_javaPart);
   }
+  void JHybridRiveLoggerSpec::setLogLevel(const std::string& level) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* level */)>("setLogLevel");
+    method(_javaPart, jni::make_jstring(level));
+  }
 
 } // namespace margelo::nitro::rive

--- a/nitrogen/generated/android/c++/JHybridRiveLoggerSpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridRiveLoggerSpec.hpp
@@ -56,6 +56,7 @@ namespace margelo::nitro::rive {
     // Methods
     void setHandler(const std::function<void(const std::string& /* level */, const std::string& /* tag */, const std::string& /* message */)>& handler) override;
     void resetHandler() override;
+    void setLogLevel(const std::string& level) override;
 
   private:
     jni::global_ref<JHybridRiveLoggerSpec::JavaPart> _javaPart;

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveLoggerSpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridRiveLoggerSpec.kt
@@ -40,6 +40,10 @@ abstract class HybridRiveLoggerSpec: HybridObject() {
   @DoNotStrip
   @Keep
   abstract fun resetHandler(): Unit
+  
+  @DoNotStrip
+  @Keep
+  abstract fun setLogLevel(level: String): Unit
 
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {

--- a/nitrogen/generated/ios/c++/HybridRiveLoggerSpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridRiveLoggerSpecSwift.hpp
@@ -79,6 +79,12 @@ namespace margelo::nitro::rive {
         std::rethrow_exception(__result.error());
       }
     }
+    inline void setLogLevel(const std::string& level) override {
+      auto __result = _swiftPart.setLogLevel(level);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+    }
 
   private:
     RNRive::HybridRiveLoggerSpec_cxx _swiftPart;

--- a/nitrogen/generated/ios/swift/HybridRiveLoggerSpec.swift
+++ b/nitrogen/generated/ios/swift/HybridRiveLoggerSpec.swift
@@ -15,6 +15,7 @@ public protocol HybridRiveLoggerSpec_protocol: HybridObject {
   // Methods
   func setHandler(handler: @escaping (_ level: String, _ tag: String, _ message: String) -> Void) throws -> Void
   func resetHandler() throws -> Void
+  func setLogLevel(level: String) throws -> Void
 }
 
 public extension HybridRiveLoggerSpec_protocol {

--- a/nitrogen/generated/ios/swift/HybridRiveLoggerSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridRiveLoggerSpec_cxx.swift
@@ -150,4 +150,15 @@ open class HybridRiveLoggerSpec_cxx {
       return bridge.create_Result_void_(__exceptionPtr)
     }
   }
+  
+  @inline(__always)
+  public final func setLogLevel(level: std.string) -> bridge.Result_void_ {
+    do {
+      try self.__implementation.setLogLevel(level: String(level))
+      return bridge.create_Result_void_()
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_void_(__exceptionPtr)
+    }
+  }
 }

--- a/nitrogen/generated/shared/c++/HybridRiveLoggerSpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridRiveLoggerSpec.cpp
@@ -16,6 +16,7 @@ namespace margelo::nitro::rive {
     registerHybrids(this, [](Prototype& prototype) {
       prototype.registerHybridMethod("setHandler", &HybridRiveLoggerSpec::setHandler);
       prototype.registerHybridMethod("resetHandler", &HybridRiveLoggerSpec::resetHandler);
+      prototype.registerHybridMethod("setLogLevel", &HybridRiveLoggerSpec::setLogLevel);
     });
   }
 

--- a/nitrogen/generated/shared/c++/HybridRiveLoggerSpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridRiveLoggerSpec.hpp
@@ -51,6 +51,7 @@ namespace margelo::nitro::rive {
       // Methods
       virtual void setHandler(const std::function<void(const std::string& /* level */, const std::string& /* tag */, const std::string& /* message */)>& handler) = 0;
       virtual void resetHandler() = 0;
+      virtual void setLogLevel(const std::string& level) = 0;
 
     protected:
       // Hybrid Setup

--- a/src/core/RiveLogger.ts
+++ b/src/core/RiveLogger.ts
@@ -1,6 +1,8 @@
 import { NitroModules } from 'react-native-nitro-modules';
 import type { RiveLogger as RiveLoggerSpec } from '../specs/RiveLogger.nitro';
 
+export type RiveLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
 const _logger = NitroModules.createHybridObject<RiveLoggerSpec>('RiveLogger');
 
 function defaultHandler(level: string, tag: string, message: string) {
@@ -25,5 +27,9 @@ export namespace RiveLog {
 
   export function resetHandler() {
     _logger.setHandler(defaultHandler);
+  }
+
+  export function setLogLevel(level: RiveLogLevel) {
+    _logger.setLogLevel(level);
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,5 +66,5 @@ export { useRiveFile, type UseRiveFileResult } from './hooks/useRiveFile';
 export { type RiveFileInput } from './hooks/useRiveFile';
 export { type SetValueAction } from './types';
 export { RiveRuntime } from './core/RiveRuntime';
-export { RiveLog } from './core/RiveLogger';
+export { RiveLog, type RiveLogLevel } from './core/RiveLogger';
 export { DataBindMode };

--- a/src/specs/RiveLogger.nitro.ts
+++ b/src/specs/RiveLogger.nitro.ts
@@ -6,4 +6,5 @@ export interface RiveLogger
     handler: (level: string, tag: string, message: string) => void
   ): void;
   resetHandler(): void;
+  setLogLevel(level: string): void;
 }


### PR DESCRIPTION
Add `RiveLog.setLogLevel(level)` to filter log output by severity. Levels: `debug`, `info`, `warn`, `error`. Default is `warn`.

## Test plan
- `RiveLog.setLogLevel('error')` suppresses warn/info/debug logs
- `RiveLog.setLogLevel('debug')` shows all logs