### PR TITLE
chore(ios): bump rive-ios to 6.19.1

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1754,7 +1754,7 @@ PODS:
     - React-logger (= 0.79.2)
     - React-perflogger (= 0.79.2)
     - React-utils (= 0.79.2)
-  - RiveRuntime (6.18.2)
+  - RiveRuntime (6.19.1)
   - RNCAsyncStorage (2.2.0):
     - DoubleConversion
     - glog
@@ -1904,7 +1904,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - RNWorklets
     - Yoga
-  - RNRive (0.4.2):
+  - RNRive (0.4.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1928,7 +1928,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RiveRuntime (= 6.18.2)
+    - RiveRuntime (= 6.19.1)
     - Yoga
   - RNScreens (4.18.0):
     - DoubleConversion
@@ -2379,12 +2379,12 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
   ReactCodegen: c63eda03ba1d94353fb97b031fc84f75a0d125ba
   ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
-  RiveRuntime: 55c7a7badd9a8389d20fc8a75b7c6accc851b69a
+  RiveRuntime: 45ab4b471316eb134fd3084a0c3219df7185eac8
   RNCAsyncStorage: a1c8cc8a99c32de1244a9cf707bf9d83d0de0f71
   RNCPicker: 28c076ae12a1056269ec0305fe35fac3086c477d
   RNGestureHandler: 6b39f4e43e4b3a0fb86de9531d090ff205a011d5
   RNReanimated: 66b68ebe3baf7ec9e716bd059d700726f250d344
-  RNRive: c02b3545abcf477d074945c5103f9f4bc9d8d672
+  RNRive: fb5b8dd078608d6840cad2dce5eeba709ac74c85
   RNScreens: f38464ec1e83bda5820c3b05ccf4908e3841c5cc
   RNWorklets: b1faafefb82d9f29c4018404a0fb33974b494a7b
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/ios/new/HybridBindableArtboard.swift
+++ b/ios/new/HybridBindableArtboard.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridBindableArtboard: HybridBindableArtboardSpec {

--- a/ios/new/HybridViewModel.swift
+++ b/ios/new/HybridViewModel.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModel: HybridViewModelSpec {

--- a/ios/new/HybridViewModelArtboardProperty.swift
+++ b/ios/new/HybridViewModelArtboardProperty.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelArtboardProperty: HybridViewModelArtboardPropertySpec {

--- a/ios/new/HybridViewModelBooleanProperty.swift
+++ b/ios/new/HybridViewModelBooleanProperty.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelBooleanProperty: HybridViewModelBooleanPropertySpec {

--- a/ios/new/HybridViewModelEnumProperty.swift
+++ b/ios/new/HybridViewModelEnumProperty.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelEnumProperty: HybridViewModelEnumPropertySpec {

--- a/ios/new/HybridViewModelImageProperty.swift
+++ b/ios/new/HybridViewModelImageProperty.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelImageProperty: HybridViewModelImagePropertySpec {

--- a/ios/new/HybridViewModelInstance.swift
+++ b/ios/new/HybridViewModelInstance.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelInstance: HybridViewModelInstanceSpec {

--- a/ios/new/HybridViewModelListProperty.swift
+++ b/ios/new/HybridViewModelListProperty.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelListProperty: HybridViewModelListPropertySpec {

--- a/ios/new/HybridViewModelNumberProperty.swift
+++ b/ios/new/HybridViewModelNumberProperty.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelNumberProperty: HybridViewModelNumberPropertySpec {

--- a/ios/new/HybridViewModelStringProperty.swift
+++ b/ios/new/HybridViewModelStringProperty.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelStringProperty: HybridViewModelStringPropertySpec {

--- a/ios/new/HybridViewModelTriggerProperty.swift
+++ b/ios/new/HybridViewModelTriggerProperty.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelTriggerProperty: HybridViewModelTriggerPropertySpec {

--- a/ios/new/RiveRuntimeLogger.swift
+++ b/ios/new/RiveRuntimeLogger.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 
 private func tagName(_ tag: RiveRuntime.RiveLog.Tag) -> String {
     switch tag {

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
   "runtimeVersions": {
-    "ios": "6.18.2",
-    "android": "11.4.0"
+    "ios": "6.19.1",
+    "android": "11.4.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Bump RiveRuntime from 6.19.0 to 6.19.1. Remove `@_spi(RiveExperimental)` imports — no longer needed with this version.