### PR TITLE
fix(ios): prevent crash on color values with high alpha

### DIFF
--- a/ios/new/HybridViewModelColorProperty.swift
+++ b/ios/new/HybridViewModelColorProperty.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridViewModelColorProperty: HybridViewModelColorPropertySpec {
@@ -32,7 +32,7 @@ class HybridViewModelColorProperty: HybridViewModelColorPropertySpec {
   }
 
   func set(value: Double) throws {
-    let color = Color(UInt32(bitPattern: Int32(value)))
+    let color = Color(UInt32(truncatingIfNeeded: Int64(value)))
     let inst = instance
     let p = prop
     Task { @MainActor in


### PR DESCRIPTION
`Int32(value)` traps when ARGB color values exceed `Int32.max` (e.g. `0xFF0000FF` = opaque blue). Uses `Int64` + `truncatingIfNeeded` for safe conversion.