### PR TITLE
fix(ios): add backend property to legacy HybridRiveFileFactory

### DIFF
--- a/ios/legacy/HybridRiveFileFactory.swift
+++ b/ios/legacy/HybridRiveFileFactory.swift
@@ -2,6 +2,7 @@ import NitroModules
 import RiveRuntime
 
 final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendable {
+  var backend: String { "legacy" }
 
   /// Asynchronously creates a `HybridRiveFileSpec` by performing the following steps:
   /// 1. Executes `check()` to validate or fetch initial data.


### PR DESCRIPTION
The experimental factory already has `var backend: String { "experimental" }`. This adds the matching property to the legacy side so `RiveFileFactory.backend` works for both backends.