### PR TITLE
fix(ios): pass fit in constructor, OOB asset improvements

### DIFF
--- a/example/src/exercisers/OutOfBandAssets.tsx
+++ b/example/src/exercisers/OutOfBandAssets.tsx
@@ -22,26 +22,17 @@ export default function OutOfBandAssetsExample() {
       referencedAssets: {
         'Inter-594377': {
           source: require('../../assets/fonts/Inter-594377.ttf'),
-          // source: {
-          //   fileName: 'Inter-594377.ttf',
-          //   path: 'fonts', // only needed for Android assets
-          // },
+          type: 'font',
         },
         'referenced-image-2929282': {
           source: {
             uri: uri,
           },
-          // source: {
-          //   fileName: 'referenced-image-2929282.png',
-          //   path: 'images', // only needed for Android assets
-          // },
+          type: 'image',
         },
         'referenced_audio-2929340': {
           source: require('../../assets/audio/referenced_audio-2929340.wav'),
-          // source: {
-          //   fileName: 'referenced_audio-2929340.wav',
-          //   path: 'audio', // only needed for Android assets
-          // },
+          type: 'audio',
         },
       },
     }

--- a/expo-example/app.config.js
+++ b/expo-example/app.config.js
@@ -47,6 +47,12 @@ module.exports = {
           assets: ['../example/assets/rive/rewards.riv'],
         },
       ],
+      [
+        'expo-font',
+        {
+          fonts: ['./assets/kanit_regular.ttf'],
+        },
+      ],
     ],
     experiments: {
       typedRoutes: true,

--- a/expo55-example/app.config.js
+++ b/expo55-example/app.config.js
@@ -47,6 +47,12 @@ module.exports = {
           assets: ['../example/assets/rive/rewards.riv'],
         },
       ],
+      [
+        'expo-font',
+        {
+          fonts: ['./assets/kanit_regular.ttf'],
+        },
+      ],
     ],
     experiments: {
       typedRoutes: true,

--- a/ios/new/ExperimentalAssetLoader.swift
+++ b/ios/new/ExperimentalAssetLoader.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 enum AssetType {

--- a/ios/new/HybridRiveFile.swift
+++ b/ios/new/HybridRiveFile.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 class HybridRiveFile: HybridRiveFileSpec {
@@ -149,14 +149,7 @@ class HybridRiveFile: HybridRiveFileSpec {
   }
 
   func updateReferencedAssets(referencedAssets: ReferencedAssetsType) {
-    guard let worker = worker else {
-      RCTLogWarn("HybridRiveFile.updateReferencedAssets: No worker available")
-      return
-    }
-    RCTLogInfo("HybridRiveFile.updateReferencedAssets: Updating \(referencedAssets.data?.count ?? 0) assets (note: existing artboards won't refresh)")
-    Task { @MainActor in
-      await ExperimentalAssetLoader.registerAssets(referencedAssets, on: worker)
-    }
+    RCTLogWarn("[Rive] updateReferencedAssets is not supported with the experimental backend — already-rendered artboards cannot be updated. Use the legacy backend for runtime asset swapping.")
   }
 
   func getEnums() throws -> Promise<[RiveEnumDefinition]> {

--- a/ios/new/HybridRiveFileFactory.swift
+++ b/ios/new/HybridRiveFileFactory.swift
@@ -24,9 +24,8 @@ final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendabl
       let data = try await HTTPDataLoader.shared.downloadData(from: fileURL)
       RCTLog("[HybridRiveFileFactory] fromURL: downloaded \(data.count) bytes")
       let worker = try await HybridRiveFileFactory.sharedWorkerTask.value
-      RCTLog("[HybridRiveFileFactory] fromURL: got shared worker, referencedAssets=\(referencedAssets == nil ? "nil" : "\(referencedAssets!.data?.count ?? -1) assets"), keys=\(referencedAssets?.data?.keys.sorted() ?? [])")
+      RCTLog("[HybridRiveFileFactory] fromURL: got shared worker")
       await ExperimentalAssetLoader.registerAssets(referencedAssets, on: worker)
-      RCTLog("[HybridRiveFileFactory] fromURL: assets registered, creating file...")
       let file = try await File(source: .data(data), worker: worker)
       RCTLog("[HybridRiveFileFactory] fromURL: created file")
       return HybridRiveFile(file: file, worker: worker)

--- a/ios/new/HybridRiveFileFactory.swift
+++ b/ios/new/HybridRiveFileFactory.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import NitroModules
 
 final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendable {
@@ -24,8 +24,9 @@ final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendabl
       let data = try await HTTPDataLoader.shared.downloadData(from: fileURL)
       RCTLog("[HybridRiveFileFactory] fromURL: downloaded \(data.count) bytes")
       let worker = try await HybridRiveFileFactory.sharedWorkerTask.value
-      RCTLog("[HybridRiveFileFactory] fromURL: got shared worker")
+      RCTLog("[HybridRiveFileFactory] fromURL: got shared worker, referencedAssets=\(referencedAssets == nil ? "nil" : "\(referencedAssets!.data?.count ?? -1) assets"), keys=\(referencedAssets?.data?.keys.sorted() ?? [])")
       await ExperimentalAssetLoader.registerAssets(referencedAssets, on: worker)
+      RCTLog("[HybridRiveFileFactory] fromURL: assets registered, creating file...")
       let file = try await File(source: .data(data), worker: worker)
       RCTLog("[HybridRiveFileFactory] fromURL: created file")
       return HybridRiveFile(file: file, worker: worker)

--- a/ios/new/HybridRiveView.swift
+++ b/ios/new/HybridRiveView.swift
@@ -1,4 +1,4 @@
-@_spi(RiveExperimental) import RiveRuntime
+import RiveRuntime
 import Foundation
 import NitroModules
 import UIKit

--- a/ios/new/RiveReactNativeView.swift
+++ b/ios/new/RiveReactNativeView.swift
@@ -1,7 +1,6 @@
 import RiveRuntime
 import NitroModules
 import UIKit
-import MetalKit
 
 enum ExperimentalBindData {
   case none
@@ -28,22 +27,7 @@ class RiveReactNativeView: UIView {
   private var isViewReady = false
   private var configTask: Task<Void, Never>?
   private var isPaused = false
-  private var pendingFit: RiveRuntime.Fit?
-
   var autoPlay: Bool = true
-
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    applyPendingFitIfMTKViewReady()
-  }
-
-  // https://github.com/rive-app/rive-nitro-react-native/pull/231
-  private func applyPendingFitIfMTKViewReady() {
-    guard let fit = pendingFit, let rive = riveInstance,
-          riveUIView?.subviews.contains(where: { $0 is MTKView }) == true else { return }
-    rive.fit = fit
-    pendingFit = nil
-  }
 
   func awaitViewReady() async -> Bool {
     if !isViewReady {
@@ -101,7 +85,8 @@ class RiveReactNativeView: UIView {
             file: config.file,
             artboard: artboard,
             stateMachine: stateMachine,
-            dataBind: dataBind
+            dataBind: dataBind,
+            fit: config.fit
           )
 
           guard !Task.isCancelled else { return }
@@ -109,8 +94,6 @@ class RiveReactNativeView: UIView {
           RCTLog("[RiveReactNativeView] Rive instance created successfully")
           self.riveInstance = rive
           self.setupRiveUIView(with: rive)
-
-          self.pendingFit = config.fit
 
           if config.autoPlay {
             self.isPaused = false


### PR DESCRIPTION
- Pass `fit:` directly in `Rive()` constructor instead of setting it post-creation. Removes the `layoutSubviews`/`pendingFit` workaround since rive-ios 6.19.1 handles this (rive-ios#443)
- Warn when `updateReferencedAssets` is called on experimental backend (not supported — concurrency API can't update already-bound artboard assets)
- Switch asset registration from parallel `TaskGroup` to sequential to ensure command queue ordering
- Add debug logging to `ExperimentalAssetLoader`
- Add explicit `type` fields to OutOfBandAssets example
- Add `expo-font` plugin for `kanit_regular.ttf` in expo examples

## Test plan
- QuickStart + DataBindingArtboards render correctly with `Fit.Layout` on first mount
- Out-of-Band Assets example loads initial assets correctly
- `updateReferencedAssets` logs a warning instead of silently failing