### PR TITLE
fix(ios): remove Xcode 26 modulemap stripping workaround

### DIFF
--- a/RNRive.podspec
+++ b/RNRive.podspec
@@ -38,28 +38,6 @@ else
   Pod::UI.puts "@rive-app/react-native: Using experimental Rive runtime backend"
 end
 
-# Xcode 26 workaround: strip .Swift Clang submodule from RiveRuntime's prebuilt
-# modulemaps to prevent ODR conflicts with locally-compiled Swift C++ interop.
-# See: https://github.com/rive-app/rive-nitro-react-native/issues/173
-if defined?(Pod::Installer)
-  module RiveXcode26SwiftModuleFix
-    def run_podfile_pre_install_hooks
-      rive_dir = File.join(sandbox.root.to_s, 'RiveRuntime')
-      if Dir.exist?(rive_dir)
-        Dir.glob(File.join(rive_dir, '**', 'module.modulemap')).each do |path|
-          content = File.read(path)
-          next unless content.include?('RiveRuntime.Swift')
-          cleaned = content.gsub(/\nmodule RiveRuntime\.Swift \{[^}]*\}\n?/m, "\n")
-          File.write(path, cleaned)
-        end
-      end
-      super
-    end
-  end
-
-  Pod::Installer.prepend(RiveXcode26SwiftModuleFix)
-end
-
 Pod::Spec.new do |s|
   s.name         = "RNRive"
   s.version      = package["version"]

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -33,24 +33,5 @@ target 'RiveExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
-
-    # Xcode 26 / Swift 6.2 workaround: strip the RiveRuntime.Swift submodule
-    # from RiveRuntime's modulemaps. Without this, Clang sees two conflicting
-    # definitions of swift::Optional / swift::String (one from the pre-built
-    # RiveRuntime XCFramework compiled with Swift 6.1, one from NitroModules
-    # compiled fresh with Swift 6.2) and fails with ODR "different definitions
-    # in different modules" errors.
-    # See: https://github.com/rive-app/rive-nitro-react-native/issues/173
-    rive_dir = File.join(installer.sandbox.root.to_s, 'RiveRuntime')
-    if Dir.exist?(rive_dir)
-      Dir.glob(File.join(rive_dir, '**', 'module.modulemap')).each do |path|
-        content = File.read(path)
-        next unless content.include?('RiveRuntime.Swift')
-        cleaned = content.gsub(/\nmodule RiveRuntime\.Swift \{[^}]*\}\n?/m, "\n")
-        File.write(path, cleaned)
-        puts "[RNRive] Stripped RiveRuntime.Swift submodule from #{path}"
-      end
-    end
-
   end
 end


### PR DESCRIPTION
Removes the workaround that stripped the `RiveRuntime.Swift` submodule from modulemaps to avoid ODR conflicts. No longer needed since the upstream XCFramework switched from C++/ObjC++ interop to C/ObjC interop — the generated Swift header no longer emits `swift::` namespace types.

Tested building with both Xcode 16.4 and Xcode 26.2 with the unstripped modulemap — no ODR errors.

**Note:** This PR depends on a RiveRuntime XCFramework built with C/ObjC interop. If the build fails with ODR errors like `'swift::Optional::init' has different definitions in different modules`, the workaround still needs to be re-added (revert this PR). You can verify by checking `grep -c 'namespace swift' RiveRuntime-Swift.h` — it should be 0.