### PR TITLE
chore(ios): remove 'Experimental' naming and debug logs

### DIFF
--- a/ios/new/AssetLoader.swift
+++ b/ios/new/AssetLoader.swift
@@ -31,7 +31,7 @@ enum AssetType {
 }
 
 @MainActor
-final class ExperimentalAssetLoader {
+final class AssetLoader {
 
   static func registerAssets(
     _ referencedAssets: ReferencedAssetsType?,
@@ -161,25 +161,21 @@ final class ExperimentalAssetLoader {
     type: AssetType,
     worker: Worker
   ) async throws {
-    RCTLogInfo("ExperimentalAssetLoader: Registering \(type) asset '\(name)' (\(data.count) bytes)")
     switch type {
     case .image:
       worker.removeGlobalImageAsset(name: name)
       let image = try await worker.decodeImage(from: data)
       worker.addGlobalImageAsset(image, name: name)
-      RCTLogInfo("ExperimentalAssetLoader: Image '\(name)' registered successfully")
 
     case .font:
       worker.removeGlobalFontAsset(name)
       let font = try await worker.decodeFont(from: data)
       worker.addGlobalFontAsset(font, name: name)
-      RCTLogInfo("ExperimentalAssetLoader: Font '\(name)' registered successfully")
 
     case .audio:
       worker.removeGlobalAudioAsset(name: name)
       let audio = try await worker.decodeAudio(from: data)
       worker.addGlobalAudioAsset(audio, name: name)
-      RCTLogInfo("ExperimentalAssetLoader: Audio '\(name)' registered successfully")
     }
   }
 }

--- a/ios/new/HybridRiveFileFactory.swift
+++ b/ios/new/HybridRiveFileFactory.swift
@@ -20,14 +20,10 @@ final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendabl
       guard let fileURL = URL(string: url) else {
         throw RuntimeError.error(withMessage: "Invalid URL: \(url)")
       }
-      RCTLog("[HybridRiveFileFactory] fromURL: downloading \(url)")
       let data = try await HTTPDataLoader.shared.downloadData(from: fileURL)
-      RCTLog("[HybridRiveFileFactory] fromURL: downloaded \(data.count) bytes")
       let worker = try await HybridRiveFileFactory.sharedWorkerTask.value
-      RCTLog("[HybridRiveFileFactory] fromURL: got shared worker")
-      await ExperimentalAssetLoader.registerAssets(referencedAssets, on: worker)
+      await AssetLoader.registerAssets(referencedAssets, on: worker)
       let file = try await File(source: .data(data), worker: worker)
-      RCTLog("[HybridRiveFileFactory] fromURL: created file")
       return HybridRiveFile(file: file, worker: worker)
     }
   }
@@ -44,7 +40,7 @@ final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendabl
       }
       let data = try FileDataLoader().loadData(from: url)
       let worker = try await HybridRiveFileFactory.sharedWorkerTask.value
-      await ExperimentalAssetLoader.registerAssets(referencedAssets, on: worker)
+      await AssetLoader.registerAssets(referencedAssets, on: worker)
       let file = try await File(source: .data(data), worker: worker)
       return HybridRiveFile(file: file, worker: worker)
     }
@@ -58,7 +54,7 @@ final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendabl
         throw RuntimeError.error(withMessage: "Could not find Rive file: \(resource).riv")
       }
       let worker = try await HybridRiveFileFactory.sharedWorkerTask.value
-      await ExperimentalAssetLoader.registerAssets(referencedAssets, on: worker)
+      await AssetLoader.registerAssets(referencedAssets, on: worker)
       let file = try await File(source: .local(resource, nil), worker: worker)
       return HybridRiveFile(file: file, worker: worker)
     }
@@ -68,13 +64,10 @@ final class HybridRiveFileFactory: HybridRiveFileFactorySpec, @unchecked Sendabl
     throws -> Promise<(any HybridRiveFileSpec)>
   {
     let data = bytes.toData(copyIfNeeded: true)
-    RCTLog("[HybridRiveFileFactory] fromBytes: got \(data.count) bytes")
     return Promise.async {
       let worker = try await HybridRiveFileFactory.sharedWorkerTask.value
-      RCTLog("[HybridRiveFileFactory] fromBytes: got shared worker")
-      await ExperimentalAssetLoader.registerAssets(referencedAssets, on: worker)
+      await AssetLoader.registerAssets(referencedAssets, on: worker)
       let file = try await File(source: .data(data), worker: worker)
-      RCTLog("[HybridRiveFileFactory] fromBytes: created file")
       return HybridRiveFile(file: file, worker: worker)
     }
   }

--- a/ios/new/HybridRiveView.swift
+++ b/ios/new/HybridRiveView.swift
@@ -11,7 +11,7 @@ typealias HybridDataBindMode = Variant__any_HybridViewModelInstanceSpec__DataBin
 
 extension Optional
 where Wrapped == HybridDataBindMode {
-  func toExperimentalBindData() throws -> ExperimentalBindData {
+  func toBindData() throws -> BindData {
     guard let value = self else {
       return .auto
     }
@@ -195,13 +195,13 @@ class HybridRiveView: HybridRiveViewSpec {
         return
       }
 
-      let config = ExperimentalViewConfiguration(
+      let config = ViewConfiguration(
         artboardName: artboardName,
         stateMachineName: stateMachineName,
         autoPlay: autoPlay ?? DefaultConfiguration.autoPlay,
         file: riveFile,
-        fit: toExperimentalFit(fit, alignment: alignment, layoutScaleFactor: layoutScaleFactor),
-        bindData: try dataBind.toExperimentalBindData()
+        fit: toRiveFit(fit, alignment: alignment, layoutScaleFactor: layoutScaleFactor),
+        bindData: try dataBind.toBindData()
       )
 
       try MainActor.assumeIsolated {
@@ -222,12 +222,12 @@ class HybridRiveView: HybridRiveViewSpec {
   private var initialUpdate = true
 
   // MARK: Helpers
-  private func toExperimentalFit(
+  private func toRiveFit(
     _ fit: Fit?,
     alignment: Alignment?,
     layoutScaleFactor: Double?
   ) -> RiveRuntime.Fit {
-    let expAlignment = toExperimentalAlignment(alignment) ?? .center
+    let expAlignment = toRiveAlignment(alignment) ?? .center
 
     switch fit ?? .contain {
     case .fill: return .fill(alignment: expAlignment)
@@ -245,7 +245,7 @@ class HybridRiveView: HybridRiveViewSpec {
     }
   }
 
-  private func toExperimentalAlignment(_ alignment: Alignment?) -> RiveRuntime.Alignment? {
+  private func toRiveAlignment(_ alignment: Alignment?) -> RiveRuntime.Alignment? {
     guard let alignment = alignment else { return nil }
 
     switch alignment {

--- a/ios/new/HybridViewModelImageProperty.swift
+++ b/ios/new/HybridViewModelImageProperty.swift
@@ -30,7 +30,6 @@ class HybridViewModelImageProperty: HybridViewModelImagePropertySpec {
       do {
         let experimentalImage = try await worker.decodeImage(from: hybridImage.rawData)
         instance.setValue(of: prop, to: experimentalImage)
-        RCTLogInfo("HybridViewModelImageProperty: Set image on path '\(prop.path)'")
       } catch {
         RCTLogError("HybridViewModelImageProperty: Failed to decode/set image: \(error)")
       }
@@ -38,8 +37,7 @@ class HybridViewModelImageProperty: HybridViewModelImagePropertySpec {
   }
 
   func addListener(onChanged: @escaping () -> Void) throws -> () -> Void {
-    // TODO: Experimental API image property listener - API changed, needs update
-    // The triggerStream method may have been removed or renamed
+    // TODO: image property listener not yet available in concurrency API
     return {}
   }
 

--- a/ios/new/HybridViewModelListProperty.swift
+++ b/ios/new/HybridViewModelListProperty.swift
@@ -7,8 +7,8 @@ class HybridViewModelListProperty: HybridViewModelListPropertySpec {
   private let worker: Worker
   private var listenerTasks: [UUID: Task<Void, Never>] = [:]
 
-  // Note: Experimental API doesn't validate property paths - non-existent properties
-  // return garbage values instead of throwing. This is a known limitation.
+  // Note: the concurrency API doesn't validate property paths — non-existent
+  // properties return garbage values instead of throwing.
   init(instance: ViewModelInstance, path: String, worker: Worker) {
     self.vmiInstance = instance
     self.prop = ListProperty(path: path)

--- a/ios/new/RiveReactNativeView.swift
+++ b/ios/new/RiveReactNativeView.swift
@@ -2,20 +2,20 @@ import RiveRuntime
 import NitroModules
 import UIKit
 
-enum ExperimentalBindData {
+enum BindData {
   case none
   case auto
   case instance(ViewModelInstance)
   case byName(String)
 }
 
-struct ExperimentalViewConfiguration {
+struct ViewConfiguration {
   let artboardName: String?
   let stateMachineName: String?
   let autoPlay: Bool
   let file: File
   let fit: RiveRuntime.Fit
-  let bindData: ExperimentalBindData
+  let bindData: BindData
 }
 
 @MainActor
@@ -38,9 +38,8 @@ class RiveReactNativeView: UIView {
     return true
   }
 
-  func configure(_ config: ExperimentalViewConfiguration, dataBindingChanged: Bool = false, reload: Bool = false, initialUpdate: Bool = false) {
+  func configure(_ config: ViewConfiguration, dataBindingChanged: Bool = false, reload: Bool = false, initialUpdate: Bool = false) {
     dispatchPrecondition(condition: .onQueue(.main))
-    RCTLog("[RiveReactNativeView] configure called - reload: \(reload), dataBindingChanged: \(dataBindingChanged), initialUpdate: \(initialUpdate)")
 
     if reload {
       cleanup()
@@ -51,10 +50,7 @@ class RiveReactNativeView: UIView {
       configTask = Task { [weak self] in
         guard let self else { return }
         do {
-          RCTLog("[RiveReactNativeView] Creating artboard: \(config.artboardName ?? "default")")
           let artboard = try await config.file.createArtboard(config.artboardName)
-
-          RCTLog("[RiveReactNativeView] Creating state machine: \(config.stateMachineName ?? "default")")
           let stateMachine = try await artboard.createStateMachine(config.stateMachineName)
 
           let dataBind: RiveRuntime.DataBind
@@ -80,7 +76,6 @@ class RiveReactNativeView: UIView {
 
           guard !Task.isCancelled else { return }
 
-          RCTLog("[RiveReactNativeView] Creating Rive instance...")
           let rive = try await RiveRuntime.Rive(
             file: config.file,
             artboard: artboard,
@@ -91,7 +86,6 @@ class RiveReactNativeView: UIView {
 
           guard !Task.isCancelled else { return }
 
-          RCTLog("[RiveReactNativeView] Rive instance created successfully")
           self.riveInstance = rive
           self.setupRiveUIView(with: rive)
 
@@ -106,7 +100,6 @@ class RiveReactNativeView: UIView {
             }
             self.viewReadyContinuations.removeAll()
           }
-          RCTLog("[RiveReactNativeView] Configuration complete!")
         } catch {
           RCTLogError("[RiveReactNativeView] Failed to configure: \(error)")
         }


### PR DESCRIPTION
- Rename `ExperimentalViewConfiguration` → `ViewConfiguration`, `ExperimentalBindData` → `BindData`, `ExperimentalAssetLoader` → `AssetLoader`
- Rename `toExperimentalFit` → `toRiveFit`, `toExperimentalAlignment` → `toRiveAlignment`
- Remove `RCTLog` debug lines from `RiveReactNativeView` and `HybridRiveFileFactory`
- Remove `RCTLogInfo` from `AssetLoader` — error/warn logs are sufficient
- Update "Experimental API" comments to "concurrency API"