### PR TITLE
chore(ios): bump rive-ios to 6.20.0

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1754,7 +1754,7 @@ PODS:
     - React-logger (= 0.79.2)
     - React-perflogger (= 0.79.2)
     - React-utils (= 0.79.2)
-  - RiveRuntime (6.19.2)
+  - RiveRuntime (6.20.0)
   - RNCAsyncStorage (2.2.0):
     - DoubleConversion
     - glog
@@ -1928,7 +1928,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RiveRuntime (= 6.19.2)
+    - RiveRuntime (= 6.20.0)
     - Yoga
   - RNScreens (4.18.0):
     - DoubleConversion
@@ -2379,17 +2379,17 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
   ReactCodegen: c63eda03ba1d94353fb97b031fc84f75a0d125ba
   ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
-  RiveRuntime: 4e4145d0a3ab9f287782128dfcabb8311c22e8a3
+  RiveRuntime: 12f860505e052a8b48c580f35f1d5d5cad6709b7
   RNCAsyncStorage: a1c8cc8a99c32de1244a9cf707bf9d83d0de0f71
   RNCPicker: 28c076ae12a1056269ec0305fe35fac3086c477d
   RNGestureHandler: 6b39f4e43e4b3a0fb86de9531d090ff205a011d5
   RNReanimated: 66b68ebe3baf7ec9e716bd059d700726f250d344
-  RNRive: 83953c524771838e6276e1ca47d4e060239980bf
+  RNRive: 9da1409806521455260c8b78b6ab401afdd3df3f
   RNScreens: f38464ec1e83bda5820c3b05ccf4908e3841c5cc
   RNWorklets: b1faafefb82d9f29c4018404a0fb33974b494a7b
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 9f110fc4b7aa538663cba3c14cbb1c335f43c13f
 
-PODFILE CHECKSUM: 9a418da32e324919bb5ad7351e737b8da4b84d2c
+PODFILE CHECKSUM: 6974e58448067deb1048e3b4490e929f624eea3c
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
   "runtimeVersions": {
-    "ios": "6.19.2",
+    "ios": "6.20.0",
     "android": "11.4.1"
   },
   "publishConfig": {


### PR DESCRIPTION
Bump RiveRuntime from 6.19.2 to 6.20.0. Fixes Swift/ObjC interop issue in the released version.