### PR TITLE
fix(android): await asset registration before file load, fix dispose race

### DIFF
--- a/android/src/new/java/com/margelo/nitro/rive/ExperimentalAssetLoader.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/ExperimentalAssetLoader.kt
@@ -5,54 +5,59 @@ import app.rive.AudioAsset
 import app.rive.FontAsset
 import app.rive.ImageAsset
 import app.rive.core.CommandQueue
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 object ExperimentalAssetLoader {
   private const val TAG = "ExperimentalAssetLoader"
 
-  fun registerAssets(
+  suspend fun registerAssets(
     referencedAssets: ReferencedAssetsType?,
     riveWorker: CommandQueue
   ) {
     val assetsData = referencedAssets?.data ?: return
-    val scope = CoroutineScope(Dispatchers.IO)
 
-    for ((name, assetData) in assetsData) {
-      val source = DataSourceResolver.resolve(assetData) ?: continue
-      scope.launch {
-        try {
-          val loader = source.createLoader()
-          val data = loader.load(source)
-          val type = inferAssetType(name, data, assetData.type)
-          registerAsset(data, name, type, riveWorker)
-        } catch (e: Exception) {
-          Log.e(TAG, "Failed to load asset '$name'", e)
+    coroutineScope {
+      assetsData
+        .map { (name, assetData) ->
+        async(Dispatchers.IO) {
+          try {
+            val source = DataSourceResolver.resolve(assetData) ?: return@async
+            val loader = source.createLoader()
+            val data = loader.load(source)
+            val type = inferAssetType(name, data, assetData.type)
+            registerAsset(data, name, type, riveWorker)
+          } catch (e: Exception) {
+            Log.e(TAG, "Failed to load asset '$name'", e)
+          }
         }
-      }
+      }.awaitAll()
     }
   }
 
-  fun updateAssets(
+  suspend fun updateAssets(
     referencedAssets: ReferencedAssetsType,
     riveWorker: CommandQueue
   ) {
     val assetsData = referencedAssets.data ?: return
-    val scope = CoroutineScope(Dispatchers.IO)
 
-    for ((name, assetData) in assetsData) {
-      val source = DataSourceResolver.resolve(assetData) ?: continue
-      scope.launch {
-        try {
-          val loader = source.createLoader()
-          val data = loader.load(source)
-          val type = inferAssetType(name, data, assetData.type)
-          registerAsset(data, name, type, riveWorker)
-        } catch (e: Exception) {
-          Log.e(TAG, "Failed to update asset '$name'", e)
+    coroutineScope {
+      assetsData
+        .map { (name, assetData) ->
+        async(Dispatchers.IO) {
+          try {
+            val source = DataSourceResolver.resolve(assetData) ?: return@async
+            val loader = source.createLoader()
+            val data = loader.load(source)
+            val type = inferAssetType(name, data, assetData.type)
+            registerAsset(data, name, type, riveWorker)
+          } catch (e: Exception) {
+            Log.e(TAG, "Failed to update asset '$name'", e)
+          }
         }
-      }
+      }.awaitAll()
     }
   }
 

--- a/android/src/new/java/com/margelo/nitro/rive/HybridRiveFile.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridRiveFile.kt
@@ -179,7 +179,10 @@ class HybridRiveFile(
   }
 
   override fun updateReferencedAssets(referencedAssets: ReferencedAssetsType) {
-    ExperimentalAssetLoader.updateAssets(referencedAssets, riveWorker)
+    RiveLog.w(
+      TAG,
+      "updateReferencedAssets is not supported with the experimental backend — already-rendered artboards cannot be updated. Use the legacy backend for runtime asset swapping."
+    )
   }
 
   fun registerView(view: HybridRiveView) {

--- a/example/android/.kotlin/errors/errors-1774350400244.log
+++ b/example/android/.kotlin/errors/errors-1774350400244.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/example/src/exercisers/NestedViewModelExample.tsx
+++ b/example/src/exercisers/NestedViewModelExample.tsx
@@ -5,6 +5,7 @@ import {
   ActivityIndicator,
   Button,
   TextInput,
+  ScrollView,
 } from 'react-native';
 import { useRef, useState } from 'react';
 import {
@@ -120,7 +121,7 @@ function ReplaceViewModelTest({
         file={file}
       />
 
-      <View style={styles.info}>
+      <ScrollView style={styles.info}>
         <Text style={styles.title}>replaceViewModel() Test</Text>
         <Text style={styles.description}>
           Replace vm1 with vm2's instance. After replacement, changing vm2.name
@@ -167,7 +168,7 @@ function ReplaceViewModelTest({
             ))}
           </View>
         )}
-      </View>
+      </ScrollView>
     </View>
   );
 }
@@ -187,8 +188,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   rive: {
-    flex: 1,
     width: '100%',
+    height: 300,
   },
   info: {
     padding: 16,


### PR DESCRIPTION
- **OOB assets not showing**: `registerAssets` launched fire-and-forget coroutines — file was loaded before assets finished registering. Now `suspend` with `awaitAll()`.
- **updateReferencedAssets**: logs warning (same as iOS — not supported in experimental backend).
- **NestedViewModel example**: fixed layout so Rive view doesn't get squeezed to zero when log entries appear.

## Test plan
- Out-of-Band Assets: image, font, audio all load on Android
- NestedViewModel: Rive view stays visible after pressing Replace