### PR TITLE
chore(android): rename ExperimentalAssetLoader to AssetLoader

### DIFF
--- a/android/src/new/java/com/margelo/nitro/rive/AssetLoader.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/AssetLoader.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Dispatchers
 
-object ExperimentalAssetLoader {
-  private const val TAG = "ExperimentalAssetLoader"
+object AssetLoader {
+  private const val TAG = "AssetLoader"
 
   suspend fun registerAssets(
     referencedAssets: ReferencedAssetsType?,

--- a/android/src/new/java/com/margelo/nitro/rive/HybridRiveFileFactory.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridRiveFileFactory.kt
@@ -120,7 +120,7 @@ class HybridRiveFileFactory : HybridRiveFileFactorySpec() {
   ): HybridRiveFile {
     val worker = getSharedWorker()
 
-    ExperimentalAssetLoader.registerAssets(referencedAssets, worker)
+    AssetLoader.registerAssets(referencedAssets, worker)
 
     val source = RiveFileSource.Bytes(data)
     val result = RiveFile.fromSource(source, worker)


### PR DESCRIPTION
The rive-android API is no longer experimental in 11.4.1. Matches the iOS rename done in #240.