### PR TITLE
fix(ios): remove stale experimental iOS test skips

### DIFF
--- a/android/src/new/java/com/margelo/nitro/rive/HybridRiveFile.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridRiveFile.kt
@@ -99,10 +99,8 @@ class HybridRiveFile(
       Artboard.fromFile(file)
     }
     val vmSource = ViewModelSource.DefaultForArtboard(artboard)
-    // Name is null because the Rive Android SDK does not expose the ViewModel name
-    // from a ViewModelInstance — name-dependent operations will throw UnsupportedOperationException.
-    // Track upstream: https://github.com/rive-app/rive-android/issues/XXX
-    return HybridViewModel(file, riveWorker, null, this, vmSource)
+    val vmInfo = file.getDefaultViewModelInfo(artboard)
+    return HybridViewModel(file, riveWorker, vmInfo.viewModelName, this, vmSource)
   }
 
   // Deprecated: Use defaultArtboardViewModelAsync instead

--- a/android/src/new/java/com/margelo/nitro/rive/HybridViewModel.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridViewModel.kt
@@ -14,26 +14,18 @@ import kotlinx.coroutines.runBlocking
 class HybridViewModel(
   private val riveFile: RiveFile,
   private val riveWorker: CommandQueue,
-  // Null when constructed via DefaultForArtboard — the Rive Android SDK does not expose
-  // the ViewModel name from a ViewModelInstance, so name-dependent operations are unavailable.
-  // Track: https://github.com/rive-app/rive-android/issues/XXX
   private val viewModelName: String?,
   private val parentFile: HybridRiveFile,
   private val vmSource: ViewModelSource
 ) : HybridViewModelSpec() {
   companion object {
     private const val TAG = "HybridViewModel"
-    private const val NO_NAME_ERROR =
-      "This operation requires the ViewModel name, which is unavailable for ViewModels " +
-      "obtained via defaultArtboardViewModel(). The Rive Android SDK does not yet expose " +
-      "the ViewModel name from a ViewModelInstance. Use a named ViewModel instead, or " +
-      "track the upstream fix: https://github.com/rive-app/rive-android/issues/XXX"
   }
 
   override val propertyCount: Double
     get() {
       DeprecationWarning.warn("propertyCount", "getPropertyCountAsync")
-      val name = viewModelName ?: throw UnsupportedOperationException(NO_NAME_ERROR)
+      val name = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
       return try {
         runBlocking { riveFile.getViewModelProperties(name) }.size.toDouble()
       } catch (e: Exception) {
@@ -45,7 +37,7 @@ class HybridViewModel(
   override val instanceCount: Double
     get() {
       DeprecationWarning.warn("instanceCount", "getInstanceCountAsync")
-      val name = viewModelName ?: throw UnsupportedOperationException(NO_NAME_ERROR)
+      val name = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
       return try {
         runBlocking { riveFile.getViewModelInstanceNames(name) }.size.toDouble()
       } catch (e: Exception) {
@@ -55,22 +47,22 @@ class HybridViewModel(
     }
 
   override val modelName: String
-    get() = viewModelName ?: throw UnsupportedOperationException(NO_NAME_ERROR)
+    get() = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
 
   override fun getPropertyCountAsync(): Promise<Double> {
-    val name = viewModelName ?: return Promise.rejected(UnsupportedOperationException(NO_NAME_ERROR))
+    val name = viewModelName ?: return Promise.rejected(UnsupportedOperationException("ViewModel name is unavailable"))
     return Promise.async { riveFile.getViewModelProperties(name).size.toDouble() }
   }
 
   override fun getInstanceCountAsync(): Promise<Double> {
-    val name = viewModelName ?: return Promise.rejected(UnsupportedOperationException(NO_NAME_ERROR))
+    val name = viewModelName ?: return Promise.rejected(UnsupportedOperationException("ViewModel name is unavailable"))
     return Promise.async { riveFile.getViewModelInstanceNames(name).size.toDouble() }
   }
 
   // Deprecated: Use createInstanceByNameAsync instead
   override fun createInstanceByIndex(index: Double): HybridViewModelInstanceSpec? {
     DeprecationWarning.warn("createInstanceByIndex", "createInstanceByNameAsync")
-    val name = viewModelName ?: throw UnsupportedOperationException(NO_NAME_ERROR)
+    val name = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
     return try {
       val idx = index.toInt()
       val instanceNames = runBlocking { riveFile.getViewModelInstanceNames(name) }
@@ -86,7 +78,7 @@ class HybridViewModel(
   }
 
   private suspend fun createInstanceByNameImpl(instanceName: String): HybridViewModelInstanceSpec? {
-    val name = viewModelName ?: throw UnsupportedOperationException(NO_NAME_ERROR)
+    val name = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
     val instanceNames = riveFile.getViewModelInstanceNames(name)
     if (!instanceNames.contains(instanceName)) return null
     val source = vmSource.namedInstance(instanceName)
@@ -97,7 +89,7 @@ class HybridViewModel(
   // Deprecated: Use createInstanceByNameAsync instead
   override fun createInstanceByName(name: String): HybridViewModelInstanceSpec? {
     DeprecationWarning.warn("createInstanceByName", "createInstanceByNameAsync")
-    if (viewModelName == null) throw UnsupportedOperationException(NO_NAME_ERROR)
+    if (viewModelName == null) throw UnsupportedOperationException("ViewModel name is unavailable")
     return try {
       runBlocking { createInstanceByNameImpl(name) }
     } catch (e: UnsupportedOperationException) {
@@ -109,7 +101,7 @@ class HybridViewModel(
   }
 
   override fun createInstanceByNameAsync(name: String): Promise<HybridViewModelInstanceSpec?> {
-    if (viewModelName == null) return Promise.rejected(UnsupportedOperationException(NO_NAME_ERROR))
+    if (viewModelName == null) return Promise.rejected(UnsupportedOperationException("ViewModel name is unavailable"))
     return Promise.async { createInstanceByNameImpl(name) }
   }
 

--- a/example/__tests__/databinding-advanced.harness.ts
+++ b/example/__tests__/databinding-advanced.harness.ts
@@ -193,9 +193,6 @@ describe('List Properties', () => {
   });
 
   it('getInstanceAt returns ViewModelInstances with correct names', async () => {
-    if (isExperimentalIOS) {
-      return; // getInstanceAt crashes experimental iOS renderer (rive::CommandQueue::processMessages)
-    }
     const file = await loadFile(DATABINDING_LISTS);
     const vm = file.viewModelByName('DevRel');
     expectDefined(vm);
@@ -216,9 +213,6 @@ describe('List Properties', () => {
   });
 
   it('addInstance increases length', async () => {
-    if (isExperimentalIOS) {
-      return; // list mutations crash experimental iOS renderer (rive::CommandQueue::processMessages)
-    }
     const file = await loadFile(DATABINDING_LISTS);
     const devRelVM = file.viewModelByName('DevRel');
     expectDefined(devRelVM);
@@ -248,9 +242,6 @@ describe('List Properties', () => {
   });
 
   it('removeInstanceAt decreases length', async () => {
-    if (isExperimentalIOS) {
-      return; // list mutations crash experimental iOS renderer (rive::CommandQueue::processMessages)
-    }
     const file = await loadFile(DATABINDING_LISTS);
     const vm = file.viewModelByName('DevRel');
     expectDefined(vm);
@@ -266,9 +257,6 @@ describe('List Properties', () => {
   });
 
   it('swap reorders items', async () => {
-    if (isExperimentalIOS) {
-      return; // list mutations crash experimental iOS renderer (rive::CommandQueue::processMessages)
-    }
     const file = await loadFile(DATABINDING_LISTS);
     const vm = file.viewModelByName('DevRel');
     expectDefined(vm);
@@ -292,9 +280,6 @@ describe('List Properties', () => {
   });
 
   it('addInstanceAt inserts at position', async () => {
-    if (isExperimentalIOS) {
-      return; // list mutations crash experimental iOS renderer (rive::CommandQueue::processMessages)
-    }
     const file = await loadFile(DATABINDING_LISTS);
     const devRelVM = file.viewModelByName('DevRel');
     expectDefined(devRelVM);
@@ -322,9 +307,6 @@ describe('List Properties', () => {
 
 describe('Artboard Properties', () => {
   it('artboardProperty returns defined properties', async () => {
-    if (isExperimentalIOS) {
-      return; // artboard_db_test.riv crashes experimental iOS renderer on load
-    }
     const file = await loadFile(ARTBOARD_DB_TEST);
     const vm = file.defaultArtboardViewModel();
     expectDefined(vm);
@@ -339,9 +321,6 @@ describe('Artboard Properties', () => {
   });
 
   it('getBindableArtboard returns a BindableArtboard with correct name', async () => {
-    if (isExperimentalIOS) {
-      return;
-    }
     const file = await loadFile(ARTBOARD_DB_TEST);
     const artboardNames = file.artboardNames;
     expect(artboardNames.length).toBeGreaterThan(0);
@@ -352,9 +331,6 @@ describe('Artboard Properties', () => {
   });
 
   it('artboardProperty.set(bindable) does not throw', async () => {
-    if (isExperimentalIOS) {
-      return;
-    }
     const file = await loadFile(ARTBOARD_DB_TEST);
     const vm = file.defaultArtboardViewModel();
     expectDefined(vm);
@@ -373,9 +349,6 @@ describe('Artboard Properties', () => {
 
 describe('Image Properties', () => {
   it('imageProperty("bound_image") returns defined property', async () => {
-    if (isExperimentalIOS) {
-      return; // databinding_images.riv crashes experimental iOS renderer on load
-    }
     const file = await loadFile(DATABINDING_IMAGES);
     const vm = file.viewModelByName('MyViewModel');
     expectDefined(vm);

--- a/example/__tests__/databinding-advanced.harness.ts
+++ b/example/__tests__/databinding-advanced.harness.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'react-native-harness';
-import { Platform } from 'react-native';
 import type {
   ViewModelInstance,
   ViewModelStringProperty,
@@ -10,9 +9,6 @@ const DATABINDING = require('../assets/rive/databinding.riv');
 const DATABINDING_LISTS = require('../assets/rive/databinding_lists.riv');
 const DATABINDING_IMAGES = require('../assets/rive/databinding_images.riv');
 const ARTBOARD_DB_TEST = require('../assets/rive/artboard_db_test.riv');
-
-const isExperimentalIOS =
-  Platform.OS === 'ios' && RiveFileFactory.getBackend() === 'experimental';
 
 function expectDefined<T>(value: T): asserts value is NonNullable<T> {
   expect(value).toBeDefined();

--- a/example/__tests__/viewmodel-properties.harness.ts
+++ b/example/__tests__/viewmodel-properties.harness.ts
@@ -66,14 +66,6 @@ describe('ViewModel Properties', () => {
   });
 
   it('colorProperty get/set works', async () => {
-    if (
-      Platform.OS === 'ios' &&
-      RiveFileFactory.getBackend() === 'experimental'
-    ) {
-      // rive-ios experimental: Color.argbValue is internal, getter returns 0
-      return;
-    }
-
     const instance = await createGordonInstance();
     const colorProperty = instance.colorProperty('favourite_color');
     expectDefined(colorProperty);
@@ -205,14 +197,6 @@ describe('Property Listeners', () => {
   });
 
   it('colorProperty addListener returns cleanup function', async () => {
-    if (
-      Platform.OS === 'ios' &&
-      RiveFileFactory.getBackend() === 'experimental'
-    ) {
-      // rive-ios experimental: Color.argbValue is internal, addListener not supported
-      return;
-    }
-
     const instance = await createGordonInstance();
     const prop = instance.colorProperty('favourite_color');
     expectDefined(prop);

--- a/example/package.json
+++ b/example/package.json
@@ -34,7 +34,6 @@
     "@react-native-community/cli": "18.0.0",
     "@react-native-community/cli-platform-android": "18.0.0",
     "@react-native-community/cli-platform-ios": "18.0.0",
-    "@react-native-harness/coverage-ios": "file:/Users/boga/Work/Margelo/react-native-harness/packages/coverage-ios",
     "@react-native-harness/platform-android": "1.0.0",
     "@react-native-harness/platform-apple": "1.0.0",
     "@react-native/babel-preset": "0.79.2",

--- a/example/rn-harness.config.mjs
+++ b/example/rn-harness.config.mjs
@@ -24,12 +24,4 @@ export default {
     }),
   ],
   defaultRunner: 'ios',
-
-  coverage: {
-    native: {
-      ios: {
-        pods: ['RNRive', 'RiveRuntime'],
-      },
-    },
-  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4431,17 +4431,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-harness/coverage-ios@file:/Users/boga/Work/Margelo/react-native-harness/packages/coverage-ios::locator=react-native-rive-example%40workspace%3Aexample":
-  version: 1.0.0
-  resolution: "@react-native-harness/coverage-ios@file:/Users/boga/Work/Margelo/react-native-harness/packages/coverage-ios#/Users/boga/Work/Margelo/react-native-harness/packages/coverage-ios::hash=aee41f&locator=react-native-rive-example%40workspace%3Aexample"
-  dependencies:
-    tslib: ^2.3.0
-  peerDependencies:
-    react-native: "*"
-  checksum: c44138fb2bbeafef88ca9469f2b46901428b7aa51736b903142e4025124d0df11ef720182835178b035a36e3ad843d82dd6ad3cdbe9e1e84640b3dd26195ee05
-  languageName: node
-  linkType: hard
-
 "@react-native-harness/jest@npm:1.0.0":
   version: 1.0.0
   resolution: "@react-native-harness/jest@npm:1.0.0"
@@ -16321,7 +16310,6 @@ __metadata:
     "@react-native-community/cli": 18.0.0
     "@react-native-community/cli-platform-android": 18.0.0
     "@react-native-community/cli-platform-ios": 18.0.0
-    "@react-native-harness/coverage-ios": "file:/Users/boga/Work/Margelo/react-native-harness/packages/coverage-ios"
     "@react-native-harness/platform-android": 1.0.0
     "@react-native-harness/platform-apple": 1.0.0
     "@react-native-picker/picker": ^2.11.4


### PR DESCRIPTION
Remove stale `isExperimentalIOS` test skips and fix Android ViewModel name resolution.

- **Test skips removed:** Color property (`argbValue` now public in rive-ios 6.19.2), artboard/list/image databinding (crashes fixed in experimental renderer)
- **Android fix:** Use `getDefaultViewModelInfo()` (available since rive-android 11.3.2) to resolve ViewModel name for `defaultArtboardViewModel()`, enabling `createInstanceByName` and other name-dependent operations

All 105 harness tests pass on both iOS experimental and Android.