### PR TITLE
chore: bump react-native-harness to 1.1.0

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -34,8 +34,8 @@
     "@react-native-community/cli": "19.1.2",
     "@react-native-community/cli-platform-android": "19.1.2",
     "@react-native-community/cli-platform-ios": "19.1.2",
-    "@react-native-harness/platform-android": "1.0.0",
-    "@react-native-harness/platform-apple": "1.0.0",
+    "@react-native-harness/platform-android": "1.1.0",
+    "@react-native-harness/platform-apple": "1.1.0",
     "@react-native/babel-preset": "0.80.3",
     "@react-native/metro-config": "0.80.3",
     "@react-native/typescript-config": "0.80.3",
@@ -44,7 +44,7 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "deep-equal": "^2.2.3",
     "react-native-builder-bob": "^0.40.10",
-    "react-native-harness": "1.0.0"
+    "react-native-harness": "1.1.0"
   },
   "engines": {
     "node": ">=18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4368,176 +4368,193 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-harness/babel-preset@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/babel-preset@npm:1.0.0"
+"@react-native-harness/babel-preset@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/babel-preset@npm:1.1.0"
   dependencies:
     "@babel/plugin-transform-class-static-block": ^7.27.1
     babel-plugin-istanbul: ^7.0.1
   peerDependencies:
     "@babel/core": ^7.22.0
     "@babel/plugin-transform-react-jsx": "*"
-  checksum: 77f95a3adc252d1188ddbd1ed09552b7861052bbfb3c9f03950176f00df31327a8ffa0a63b2b5801852e357e126a6e89133f8a60380d9bc1712d1baa9a6743c3
+  checksum: f939dfd75f4ee45e260d7e4e8468befc230d8857522be610abd2c5745aae2ae1ce346f4fa9e7eb17e5493d576f797663fb2dea018576d1c485271a8b9dc8b4cc
   languageName: node
   linkType: hard
 
-"@react-native-harness/bridge@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/bridge@npm:1.0.0"
+"@react-native-harness/bridge@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/bridge@npm:1.1.0"
   dependencies:
-    "@react-native-harness/platforms": 1.0.0
-    "@react-native-harness/tools": 1.0.0
+    "@react-native-harness/platforms": 1.1.0
+    "@react-native-harness/tools": 1.1.0
     birpc: ^2.4.0
     pixelmatch: ^7.1.0
     pngjs: ^7.0.0
     ssim.js: ^3.5.0
     tslib: ^2.3.0
     ws: ^8.18.2
-  checksum: 523c65a0e8da19a4d280a50f1d5835ef4a77fe8a069eb41f8a8857bb7ed3f6c0e3c964a30e0a1db9ed6b241f4f61fe0657a63a53ab1db8012a16cda58ee6dda9
+  checksum: 646e4b8fe33fbef9c66b9d8234e487dc5a1c9e681f1433186034cb52bfbdc72363727bc9ffd8d5b89b34edc5cf569549982c29cb4bbdbd9e67172cbf81f05c1e
   languageName: node
   linkType: hard
 
-"@react-native-harness/bundler-metro@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/bundler-metro@npm:1.0.0"
+"@react-native-harness/bundler-metro@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/bundler-metro@npm:1.1.0"
   dependencies:
-    "@react-native-harness/config": 1.0.0
-    "@react-native-harness/metro": 1.0.0
-    "@react-native-harness/tools": 1.0.0
+    "@react-native-harness/babel-preset": 1.1.0
+    "@react-native-harness/config": 1.1.0
+    "@react-native-harness/runtime": 1.1.0
+    "@react-native-harness/tools": 1.1.0
+    "@react-native/metro-config": "*"
     connect: ^3.7.0
     nocache: ^4.0.0
     tslib: ^2.3.0
   peerDependencies:
     metro: "*"
+    metro-cache: "*"
     metro-config: "*"
-  checksum: 3dc8794bd978a9eb77b710304d54a0e4283fcb522b0a97002a4746d92632b52aad96f936e122f62335dc00183fd9301c37e4c34a8efcd8f3d1e39ada201ed159
+    metro-resolver: "*"
+  checksum: 67fb517b5d7a364d39c063978c78fffd0d658e5bf051d94c62a2ffd396dd6cbddc72043af1d5518ab1edb465a749e8e3a53f8b4aaf9b18dd99ff57c1bdd8d7ea
   languageName: node
   linkType: hard
 
-"@react-native-harness/cli@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/cli@npm:1.0.0"
+"@react-native-harness/cli@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/cli@npm:1.1.0"
   dependencies:
-    "@react-native-harness/bridge": 1.0.0
-    "@react-native-harness/config": 1.0.0
-    "@react-native-harness/platforms": 1.0.0
-    "@react-native-harness/tools": 1.0.0
+    "@react-native-harness/bridge": 1.1.0
+    "@react-native-harness/config": 1.1.0
+    "@react-native-harness/platforms": 1.1.0
+    "@react-native-harness/tools": 1.1.0
     tslib: ^2.3.0
   peerDependencies:
     jest-cli: "*"
-  checksum: e14b1566caea7c4d8c63aed9ca69030a1455f5fe3979ff756c7d17b9db8d058c3b19d501d3eefc33209838879c23fd2d3729da498ee2fc3385d32908089e93fe
+  checksum: 0bf10b9094443500ce9f1371844810323f7802f437cbafe4f86c5b75e934ff1431a7e23d4d5ee17d4a0febe2473e37346415982c0a2d1983ab3e0b67273f0bc1
   languageName: node
   linkType: hard
 
-"@react-native-harness/config@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/config@npm:1.0.0"
+"@react-native-harness/config@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/config@npm:1.1.0"
   dependencies:
-    "@react-native-harness/tools": 1.0.0
+    "@react-native-harness/plugins": 1.1.0
+    "@react-native-harness/tools": 1.1.0
     tslib: ^2.3.0
     zod: ^3.25.67
-  checksum: c63c3b757a007b6ecb969e90011554e2d092ea103eb87ba83d6b98aa08624b5b602ec897b4e97dae3e7354689ab8e9182d4cbcb278c28420f3038619c233fda2
+  checksum: 66cff4ae79cd4f0f2c4158eb576199d2ae5eefed726244e1999255602180488dff6084fea6faa45e173a4157d72354f04d8bcd12cbb90feaaf72dc8ab0b80f2f
   languageName: node
   linkType: hard
 
-"@react-native-harness/jest@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/jest@npm:1.0.0"
+"@react-native-harness/jest@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/jest@npm:1.1.0"
   dependencies:
     "@jest/test-result": ^30.2.0
-    "@react-native-harness/bridge": 1.0.0
-    "@react-native-harness/bundler-metro": 1.0.0
-    "@react-native-harness/config": 1.0.0
-    "@react-native-harness/platforms": 1.0.0
-    "@react-native-harness/tools": 1.0.0
+    "@react-native-harness/bridge": 1.1.0
+    "@react-native-harness/bundler-metro": 1.1.0
+    "@react-native-harness/config": 1.1.0
+    "@react-native-harness/platforms": 1.1.0
+    "@react-native-harness/plugins": 1.1.0
+    "@react-native-harness/tools": 1.1.0
     chalk: ^4.1.2
     jest-message-util: ^30.2.0
     jest-util: ^30.2.0
     p-limit: ^7.1.1
     tslib: ^2.3.0
     yargs: ^17.7.2
-  checksum: 81a1a13eb335d4ae284f4c218ab6616cb192e545e2509735726440012098c585d9e06789fc0c7ee44554905ca65be460b0d02221d0e10e01ea1ba9761f54143f
+  checksum: 0cc0cab2d3a9c27edaeca0b55344505f54aba0975c7be95b5aae3e154940003778860728df09146a3b3219f7fba073ad92ed152c9ac18761e4eda816f4be6e67
   languageName: node
   linkType: hard
 
-"@react-native-harness/metro@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/metro@npm:1.0.0"
+"@react-native-harness/metro@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/metro@npm:1.1.0"
   dependencies:
-    "@react-native-harness/babel-preset": 1.0.0
-    "@react-native-harness/config": 1.0.0
     tslib: ^2.3.0
   peerDependencies:
-    "@react-native-harness/runtime": 1.0.0
     metro: "*"
-  checksum: 7eb5f8fb50f25d0ce7f56bcadbab63a01ca40149e4f6b15071f237dd2f4853f89c5a2b3de8b624a76f2a601c1f8a6df7ea70891fb4ca8c6107a95f8e1e00288e
+  checksum: 67206acebb52e95dc03d2c0139815e5fcf31873ba862fad97a8719b5d07a64c99013ef566e5801915861b414bebcb5794434ed45500d7d5abfd5ecca39c66b9b
   languageName: node
   linkType: hard
 
-"@react-native-harness/platform-android@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/platform-android@npm:1.0.0"
+"@react-native-harness/platform-android@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/platform-android@npm:1.1.0"
   dependencies:
-    "@react-native-harness/config": 1.0.0
-    "@react-native-harness/platforms": 1.0.0
-    "@react-native-harness/tools": 1.0.0
+    "@react-native-harness/config": 1.1.0
+    "@react-native-harness/platforms": 1.1.0
+    "@react-native-harness/tools": 1.1.0
     tslib: ^2.3.0
     zod: ^3.25.67
-  checksum: 40f77544820c1c3103d8de31abd624ff0a2df19ff78a71d7a20b9bb0416c3b7ec562520f03c1a9936cdef14c9d1df51d1f17d658ce773294045c99d3b0237b2d
+  checksum: aea531ee6fb571db2fac65c4a87a11943fe99279f66ada6a88bbac7e7ceb9d12c9941d79a9158b72ccd04f8f0a2d0aa294fdbc01ef2a4e3a7a3fa9e2d6ad51d7
   languageName: node
   linkType: hard
 
-"@react-native-harness/platform-apple@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/platform-apple@npm:1.0.0"
+"@react-native-harness/platform-apple@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/platform-apple@npm:1.1.0"
   dependencies:
-    "@react-native-harness/platforms": 1.0.0
-    "@react-native-harness/tools": 1.0.0
+    "@react-native-harness/config": 1.1.0
+    "@react-native-harness/platforms": 1.1.0
+    "@react-native-harness/tools": 1.1.0
     tslib: ^2.3.0
     zod: ^3.25.67
-  checksum: 30393748eaf9d7ef5aed5e0c9fdd1e758ad901b76387f3b659b2e74cc21dc6bf0a4535b49e397794e34d5f34da1fd230009fba8908dbcc1dce57d9f438a461f1
+  checksum: 065ce85cd60fd31ba849b50043993aae47b9a1598754e95f5d5d5ac29802bf1d86cecf5c35793e5b4761d136942afe13c2da9046cd21d57a88084789e59e9186
   languageName: node
   linkType: hard
 
-"@react-native-harness/platforms@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/platforms@npm:1.0.0"
+"@react-native-harness/platforms@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/platforms@npm:1.1.0"
   dependencies:
     tslib: ^2.3.0
-  checksum: 4bdf3d164481d6192b7bdd2c1436e15a9e9c14a7b05598ab301fc37ac6979153be5ac718dddcdae1ea879b65ddf047267bd4927a5fa758602569d51bd3c401b2
+  checksum: 3605c9a976a246f688d0c9bfad7ed6eb699ff313f26f0fbcc1f3e18a21f156de9c77f146c3d0cf509d128dadd5d8db46ea7bc300658c5eee78a6a8f8932c2f52
   languageName: node
   linkType: hard
 
-"@react-native-harness/runtime@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/runtime@npm:1.0.0"
+"@react-native-harness/plugins@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/plugins@npm:1.1.0"
   dependencies:
-    "@react-native-harness/bridge": 1.0.0
+    "@react-native-harness/bridge": 1.1.0
+    "@react-native-harness/platforms": 1.1.0
+    "@react-native-harness/tools": 1.1.0
+    hookable: ^6.1.0
+    tslib: ^2.3.0
+  checksum: 4b9e116f14b1329ffd31fdde9b1081417633e27984b0e6982e0ce379769b1bb47331795b74f38ddd4f96c7f38fdca78bfc45d104d91d4292a4508fca054a5241
+  languageName: node
+  linkType: hard
+
+"@react-native-harness/runtime@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/runtime@npm:1.1.0"
+  dependencies:
+    "@react-native-harness/bridge": 1.1.0
     "@vitest/expect": 4.0.16
     "@vitest/spy": 4.0.16
     chai: ^6.2.2
     event-target-shim: ^6.0.2
+    react-native-url-polyfill: ^3.0.0
     use-sync-external-store: ^1.6.0
     zustand: ^5.0.5
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: ab7a15e0581e2d604e2bb3032fbfd8a81dc387c1914ccde3fbd24fb4783e71251916f41aa748782529cd47dd7df9061a0a08db0ff1aef55b859b3fb9a334fb0a
+  checksum: 29162c704a9cd4697995340cd38ff804f136d9b3b5a17e1cfcebb6074e66cd022dff46978520aa4cf4e6bc1a8a6d2bbbfc0a801c118bdd7c2aadd1f4071cfef6
   languageName: node
   linkType: hard
 
-"@react-native-harness/tools@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@react-native-harness/tools@npm:1.0.0"
+"@react-native-harness/tools@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@react-native-harness/tools@npm:1.1.0"
   dependencies:
     "@clack/prompts": 1.0.0-alpha.9
-    is-unicode-supported: ^0.1.0
     nano-spawn: ^1.0.2
     picocolors: ^1.1.1
     tslib: ^2.3.0
   peerDependencies:
     react-native: "*"
-  checksum: 3c897820164918f0fc18b90b8e02507d4006f93c4c3d2934d3bf9d829588a72fa99545be95df5b275648ebf2e871dd04295dbac9b41f64a1913eb37d865dd7de
+  checksum: 23e36fe78f3adf3ca48b5897abd6168a568e27e1182ef72224e0deed9f675a1465ed5ac7d06a5fb5c526e37c9ba606437e6db6b37ceddc0e70fd71e3e0319060
   languageName: node
   linkType: hard
 
@@ -4616,6 +4633,16 @@ __metadata:
     "@babel/traverse": ^7.25.3
     "@react-native/codegen": 0.83.6
   checksum: 601c69cd3cf4d710210045338ef3711dfabf4c4db659b03e5c30421dcb449ff0a2588c787488317a28f06018f175ac50c322c8e1317285b51d39af262d10d84d
+  languageName: node
+  linkType: hard
+
+"@react-native/babel-plugin-codegen@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/babel-plugin-codegen@npm:0.85.3"
+  dependencies:
+    "@babel/traverse": ^7.29.0
+    "@react-native/codegen": 0.85.3
+  checksum: 44a694bdedd35ed412e041300cb065b4bbc19b2379363d720f4a0070fcd996c8559131ef2358e95273949a3e61b901fc1218ffaa60015d8059398509a1ad39a5
   languageName: node
   linkType: hard
 
@@ -4839,6 +4866,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/babel-preset@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/babel-preset@npm:0.85.3"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/plugin-proposal-export-default-from": ^7.24.7
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-syntax-export-default-from": ^7.24.7
+    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
+    "@babel/plugin-syntax-optional-chaining": ^7.8.3
+    "@babel/plugin-transform-async-generator-functions": ^7.25.4
+    "@babel/plugin-transform-async-to-generator": ^7.24.7
+    "@babel/plugin-transform-block-scoping": ^7.25.0
+    "@babel/plugin-transform-class-properties": ^7.25.4
+    "@babel/plugin-transform-classes": ^7.25.4
+    "@babel/plugin-transform-destructuring": ^7.24.8
+    "@babel/plugin-transform-flow-strip-types": ^7.25.2
+    "@babel/plugin-transform-for-of": ^7.24.7
+    "@babel/plugin-transform-modules-commonjs": ^7.24.8
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.24.7
+    "@babel/plugin-transform-nullish-coalescing-operator": ^7.24.7
+    "@babel/plugin-transform-optional-catch-binding": ^7.24.7
+    "@babel/plugin-transform-optional-chaining": ^7.24.8
+    "@babel/plugin-transform-private-methods": ^7.24.7
+    "@babel/plugin-transform-private-property-in-object": ^7.24.7
+    "@babel/plugin-transform-react-display-name": ^7.24.7
+    "@babel/plugin-transform-react-jsx": ^7.25.2
+    "@babel/plugin-transform-react-jsx-self": ^7.24.7
+    "@babel/plugin-transform-react-jsx-source": ^7.24.7
+    "@babel/plugin-transform-regenerator": ^7.24.7
+    "@babel/plugin-transform-runtime": ^7.24.7
+    "@babel/plugin-transform-typescript": ^7.25.2
+    "@babel/plugin-transform-unicode-regex": ^7.24.7
+    "@react-native/babel-plugin-codegen": 0.85.3
+    babel-plugin-syntax-hermes-parser: 0.33.3
+    babel-plugin-transform-flow-enums: ^0.0.2
+    react-refresh: ^0.14.0
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: ef44b000f2784b0f0af3ccae17db87edafa28e2d82f1ad38caf18cd17474f08d2c0b3c1eeca71809aa6c532483b9e89be7cb873ab77725e9ec3c07e127039790
+  languageName: node
+  linkType: hard
+
 "@react-native/codegen@npm:0.79.2":
   version: 0.79.2
   resolution: "@react-native/codegen@npm:0.79.2"
@@ -4919,6 +4989,23 @@ __metadata:
   peerDependencies:
     "@babel/core": "*"
   checksum: af0a0199926798bfb5a8a833d6bb0bd716cf3385bb29c14d481b89513436ae2b8f035edb435b457de9ce4bb463f79e3d9f50acdc66d87dfb039069ad172dd6b2
+  languageName: node
+  linkType: hard
+
+"@react-native/codegen@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/codegen@npm:0.85.3"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/parser": ^7.29.0
+    hermes-parser: 0.33.3
+    invariant: ^2.2.4
+    nullthrows: ^1.1.1
+    tinyglobby: ^0.2.15
+    yargs: ^17.6.2
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: 717d272fd71e671b77bf36af2092e59a4a94461b2fc52e78014614067f50afd76109eef98dc5131c65df5efd6e0e9343df3495c505c287da59015f51b47f3d56
   languageName: node
   linkType: hard
 
@@ -5248,6 +5335,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native/js-polyfills@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/js-polyfills@npm:0.85.3"
+  checksum: aacda34819f40d37cbdf4544ad5a80758363806e82a988bd83d93c301b2093dc51531914b9cc50bcb91a409f43b06fd3d4f41dd8f043d46e90464341ef2e3242
+  languageName: node
+  linkType: hard
+
 "@react-native/metro-babel-transformer@npm:0.80.3":
   version: 0.80.3
   resolution: "@react-native/metro-babel-transformer@npm:0.80.3"
@@ -5259,6 +5353,32 @@ __metadata:
   peerDependencies:
     "@babel/core": "*"
   checksum: 6007282b11fcdaf8a8e0d823fb71717c11fc1617c3a91a8edf2a16f7f1457b28e073d6374bf6a516026095937975b1ab711cc4554f617ea12764136e4bc3d832
+  languageName: node
+  linkType: hard
+
+"@react-native/metro-babel-transformer@npm:0.85.3":
+  version: 0.85.3
+  resolution: "@react-native/metro-babel-transformer@npm:0.85.3"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@react-native/babel-preset": 0.85.3
+    hermes-parser: 0.33.3
+    nullthrows: ^1.1.1
+  peerDependencies:
+    "@babel/core": "*"
+  checksum: fbff8a901c6c3a3aafba3133d771c026e0f50eb0c19e47bb25a3f65a550a7c7d8dd9ca30665275d691cc8cf5595d2f8fc92bde9634e1a6b035dd7fbab3f6057f
+  languageName: node
+  linkType: hard
+
+"@react-native/metro-config@npm:*":
+  version: 0.85.3
+  resolution: "@react-native/metro-config@npm:0.85.3"
+  dependencies:
+    "@react-native/js-polyfills": 0.85.3
+    "@react-native/metro-babel-transformer": 0.85.3
+    metro-config: ^0.84.3
+    metro-runtime: ^0.84.3
+  checksum: 9a0af6d190df911b5e1b5b346b82e2dffeb6a703c832391e3f7b8bd1ac13751d5a2d7a0ef852cdae8b8474fee07783f49b9daa2a9e8b55c9539bd59f4dd609fc
   languageName: node
   linkType: hard
 
@@ -7222,6 +7342,15 @@ __metadata:
   dependencies:
     hermes-parser: 0.32.0
   checksum: ec76abeefabf940e2d571db3b47d022a9be7602286133291e8e047d4855af6a8afc079e4631bc9a56209d751fad54b5199932a55753b1e2b56a719d20e2d5065
+  languageName: node
+  linkType: hard
+
+"babel-plugin-syntax-hermes-parser@npm:0.33.3":
+  version: 0.33.3
+  resolution: "babel-plugin-syntax-hermes-parser@npm:0.33.3"
+  dependencies:
+    hermes-parser: 0.33.3
+  checksum: 250394dbe9fc7b6b2235ed7d0eaed287c811fbb79ab122a6d1a74f212dd85307273a06ae72e0b7f164f908f57d93f45f06183236f51d9fc704083cc67bce78c6
   languageName: node
   linkType: hard
 
@@ -11460,6 +11589,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hermes-estree@npm:0.33.3":
+  version: 0.33.3
+  resolution: "hermes-estree@npm:0.33.3"
+  checksum: b4cdd1b3d818378500a5512bf5a73b63b397b8fa5721051ed29ae7e36561150ce4e4ad1994d2d3261d5e5e1b15cd30eae52f6845ace363a742a3ceb518cfee72
+  languageName: node
+  linkType: hard
+
 "hermes-estree@npm:0.35.0":
   version: 0.35.0
   resolution: "hermes-estree@npm:0.35.0"
@@ -11512,6 +11648,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hermes-parser@npm:0.33.3":
+  version: 0.33.3
+  resolution: "hermes-parser@npm:0.33.3"
+  dependencies:
+    hermes-estree: 0.33.3
+  checksum: eee873a3efce23b1cfdcd185fbbfc3554b1a0fc2513bd74bbb687dab744e3613279e7191f8d920b988677404f14bb1d2143bd679add55fd88ab07cfea59eea11
+  languageName: node
+  linkType: hard
+
 "hermes-parser@npm:0.35.0":
   version: 0.35.0
   resolution: "hermes-parser@npm:0.35.0"
@@ -11527,6 +11672,13 @@ __metadata:
   dependencies:
     react-is: ^16.7.0
   checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
+  languageName: node
+  linkType: hard
+
+"hookable@npm:^6.1.0":
+  version: 6.1.1
+  resolution: "hookable@npm:6.1.1"
+  checksum: 552a61daa49e89767142f52f9a3f82243a9ef5e1e8cf18d92b9b4b4c9facd31fee053b030bed5a221e7f33c69a8f5be96a700c28b0b068ae729c5a31f9e12b3b
   languageName: node
   linkType: hard
 
@@ -13846,6 +13998,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-babel-transformer@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-babel-transformer@npm:0.84.4"
+  dependencies:
+    "@babel/core": ^7.25.2
+    flow-enums-runtime: ^0.0.6
+    hermes-parser: 0.35.0
+    metro-cache-key: 0.84.4
+    nullthrows: ^1.1.1
+  checksum: 0125677b87a35e469675746db1d771ef1461888aac0fa0e8ef353d35a4b10ddcbb7a592cd3bb873b8c2ecb5547d4b8be65629080fc5c5efe47ff8803cd2749fd
+  languageName: node
+  linkType: hard
+
 "metro-cache-key@npm:0.82.5":
   version: 0.82.5
   resolution: "metro-cache-key@npm:0.82.5"
@@ -13879,6 +14044,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: ^0.0.6
   checksum: 8d1f285d6987b4e57b708272c06d30ba12bc74137c7bf8c0fbcfb61ed7855e8cd3fe7a0c4890fa6c50e63719b28bc03c1c2098a33ac8d4817687feed1521133d
+  languageName: node
+  linkType: hard
+
+"metro-cache-key@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-cache-key@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+  checksum: 381f330ec25ad3823ae843e5c21ed75aa5e34f4c92231aead526f4936f4280e1a73977a8d10fecc2b1ef8f11fc884323a76b650a93c699d6b02c706c17eea7ca
   languageName: node
   linkType: hard
 
@@ -13927,6 +14101,18 @@ __metadata:
     https-proxy-agent: ^7.0.5
     metro-core: 0.83.6
   checksum: fa16bf59d40613c9a4e1ef54800bf0c186821d5c2219d9e038f80980a3a5f56200f8ed7205775b7800c5338d076f8ff2158ea4be93f5e61a12036c49c13c6a42
+  languageName: node
+  linkType: hard
+
+"metro-cache@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-cache@npm:0.84.4"
+  dependencies:
+    exponential-backoff: ^3.1.1
+    flow-enums-runtime: ^0.0.6
+    https-proxy-agent: ^7.0.5
+    metro-core: 0.84.4
+  checksum: b8aa2749588a8ca6030930adc7088c7ccac3107be90a188e6b21e76eb0c105a559313f1201623627771f49326515081e1ffceac09e9055aad8cccc27b4feb008
   languageName: node
   linkType: hard
 
@@ -13994,6 +14180,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-config@npm:0.84.4, metro-config@npm:^0.84.3":
+  version: 0.84.4
+  resolution: "metro-config@npm:0.84.4"
+  dependencies:
+    connect: ^3.6.5
+    flow-enums-runtime: ^0.0.6
+    jest-validate: ^29.7.0
+    metro: 0.84.4
+    metro-cache: 0.84.4
+    metro-core: 0.84.4
+    metro-runtime: 0.84.4
+    yaml: ^2.6.1
+  checksum: 1a3255483c6f2a5b9eed7a74cf41b17b3ac4e04183c545185948e962871318033c5d39a480e214d40b6bdcb66d4db960ec6618c4c522cc6c0e17fada90fbe4de
+  languageName: node
+  linkType: hard
+
 "metro-core@npm:0.82.5, metro-core@npm:^0.82.0, metro-core@npm:^0.82.2":
   version: 0.82.5
   resolution: "metro-core@npm:0.82.5"
@@ -14035,6 +14237,17 @@ __metadata:
     lodash.throttle: ^4.1.1
     metro-resolver: 0.83.6
   checksum: 322ba2a2ce4a92709194e6ddc37ed4e27df2a5e1c9a51bfc47465fa01ec67d15c8e2999e869bd6cec4c09ff2701f6742fa044bb9b073203c569d200af7a2ecf3
+  languageName: node
+  linkType: hard
+
+"metro-core@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-core@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+    lodash.throttle: ^4.1.1
+    metro-resolver: 0.84.4
+  checksum: 232356fa3f1f5269653bd15428fe8c6fb7644e97fb7dc8eefd51a735420325eccb824a70de1751d2fce41607334744acd1645288f2baa1cca007073122f68d7a
   languageName: node
   linkType: hard
 
@@ -14106,6 +14319,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-file-map@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-file-map@npm:0.84.4"
+  dependencies:
+    debug: ^4.4.0
+    fb-watchman: ^2.0.0
+    flow-enums-runtime: ^0.0.6
+    graceful-fs: ^4.2.4
+    invariant: ^2.2.4
+    jest-worker: ^29.7.0
+    micromatch: ^4.0.4
+    nullthrows: ^1.1.1
+    walker: ^1.0.7
+  checksum: 7265aec7ae7ead5c35d50197009d337e459edfecec52871eb74244469ae68fcc70747e5f92ef8a86aefb551d398b2714c09179e9966a1affecf297a50b80c0a5
+  languageName: node
+  linkType: hard
+
 "metro-minify-terser@npm:0.82.5":
   version: 0.82.5
   resolution: "metro-minify-terser@npm:0.82.5"
@@ -14146,6 +14376,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-minify-terser@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-minify-terser@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+    terser: ^5.15.0
+  checksum: e0893b5672a4ad2bc6e2c492f9994a3eae6e633e49f2e5a52738e80260e37bb5143219ce2c337c22dd16cee850e68b99d1ba4bc378d7cc8e9cd60d636aa051b5
+  languageName: node
+  linkType: hard
+
 "metro-resolver@npm:0.82.5":
   version: 0.82.5
   resolution: "metro-resolver@npm:0.82.5"
@@ -14179,6 +14419,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: ^0.0.6
   checksum: 981ece1a8c94921d9271c9a2e251763c3771ac20a2fa07237ceda1c40400ad14ccd1a86eb64f59f7d7517139d11bfd0acc54275df11b74a40aad8b03a347af5c
+  languageName: node
+  linkType: hard
+
+"metro-resolver@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-resolver@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+  checksum: 898f2d5140404a16850b1e2cd206194d20c7118438831e0eb19c54f09703b8034e4ad56061e7f4d6ef88e92b9f6aa5dcca1b72bfa188704d3540533de32f0c5a
   languageName: node
   linkType: hard
 
@@ -14219,6 +14468,16 @@ __metadata:
     "@babel/runtime": ^7.25.0
     flow-enums-runtime: ^0.0.6
   checksum: 2d827a3bdaacc310fa96ed47dc8ef1f91916095bd7e18514d48e8fe0d14deae665f96b17ccf701e464dda67dd17b611ee959bce89253aa6695805a221af7c74b
+  languageName: node
+  linkType: hard
+
+"metro-runtime@npm:0.84.4, metro-runtime@npm:^0.84.3":
+  version: 0.84.4
+  resolution: "metro-runtime@npm:0.84.4"
+  dependencies:
+    "@babel/runtime": ^7.25.0
+    flow-enums-runtime: ^0.0.6
+  checksum: e4a5e0d7e9e33631c801f63a7340380d4a7383a23d06023233ac48e78174bec8ed78a8f5605c84a526e203241a59c0ab0215ab060e0096fc19648d207a0010dd
   languageName: node
   linkType: hard
 
@@ -14293,6 +14552,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-source-map@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-source-map@npm:0.84.4"
+  dependencies:
+    "@babel/traverse": ^7.29.0
+    "@babel/types": ^7.29.0
+    flow-enums-runtime: ^0.0.6
+    invariant: ^2.2.4
+    metro-symbolicate: 0.84.4
+    nullthrows: ^1.1.1
+    ob1: 0.84.4
+    source-map: ^0.5.6
+    vlq: ^1.0.0
+  checksum: e483887bf92775b41d2832790c0652c413329ad1c9c88de915d53be603f57a11a5edbb2cebbdcda9ce90ce32103ff28de77f370bbe3253d21975372a72e4c6ce
+  languageName: node
+  linkType: hard
+
 "metro-symbolicate@npm:0.82.5":
   version: 0.82.5
   resolution: "metro-symbolicate@npm:0.82.5"
@@ -14357,6 +14633,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-symbolicate@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-symbolicate@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+    invariant: ^2.2.4
+    metro-source-map: 0.84.4
+    nullthrows: ^1.1.1
+    source-map: ^0.5.6
+    vlq: ^1.0.0
+  bin:
+    metro-symbolicate: src/index.js
+  checksum: c4518ca46ec6cc9e7f2929d5aadd9b51da833e035ae623e3c82f2efe94e502827e58883d7b576b3d765f1d4aec17802976c13dd20f0a8944d62f97083e8304de
+  languageName: node
+  linkType: hard
+
 "metro-transform-plugins@npm:0.82.5":
   version: 0.82.5
   resolution: "metro-transform-plugins@npm:0.82.5"
@@ -14410,6 +14702,20 @@ __metadata:
     flow-enums-runtime: ^0.0.6
     nullthrows: ^1.1.1
   checksum: 846f179ee497e1ef129af77c612ef53082fc05819f6bffe73ceeb43a6334404aaff67aa0fe2b7ac22938d7d783d1414db493b3d80aede0594cdc33a7cfd59a58
+  languageName: node
+  linkType: hard
+
+"metro-transform-plugins@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-transform-plugins@npm:0.84.4"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/generator": ^7.29.1
+    "@babel/template": ^7.28.6
+    "@babel/traverse": ^7.29.0
+    flow-enums-runtime: ^0.0.6
+    nullthrows: ^1.1.1
+  checksum: 47f68a023868d0155af31e5edadfa33cb9b853932376e5cd4815b9a7150a18039861510d9611ab8c2cb765eece877ce4a72615894aaa35e0b4fa43a9023952ba
   languageName: node
   linkType: hard
 
@@ -14494,6 +14800,27 @@ __metadata:
     metro-transform-plugins: 0.83.6
     nullthrows: ^1.1.1
   checksum: fa7b9eaea43483cf6ebb5f07c804ab78f4dadb33d2d22fb19ee7c1323f41e8b215c811acb8cd0563312e8d888168070843ef14ee265f13f421902ad9b7f3d41a
+  languageName: node
+  linkType: hard
+
+"metro-transform-worker@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro-transform-worker@npm:0.84.4"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/generator": ^7.29.1
+    "@babel/parser": ^7.29.0
+    "@babel/types": ^7.29.0
+    flow-enums-runtime: ^0.0.6
+    metro: 0.84.4
+    metro-babel-transformer: 0.84.4
+    metro-cache: 0.84.4
+    metro-cache-key: 0.84.4
+    metro-minify-terser: 0.84.4
+    metro-source-map: 0.84.4
+    metro-transform-plugins: 0.84.4
+    nullthrows: ^1.1.1
+  checksum: ec6f4966865de6f5f683d2295a7ad498e97635e09eaa042f93f4a886fdcb017176555100b0f7746fa32d1d8a967c8eda8a533d2697614b730441da127d3226a2
   languageName: node
   linkType: hard
 
@@ -14694,6 +15021,55 @@ __metadata:
   bin:
     metro: src/cli.js
   checksum: 5f41d64adfc1fe530a483b18589335cc2bd67057678071ce30b57d1e693cc43cfd646fc8159b4b30344664d181b11892dca96d33a22a2f6a7cee24dd270251f7
+  languageName: node
+  linkType: hard
+
+"metro@npm:0.84.4":
+  version: 0.84.4
+  resolution: "metro@npm:0.84.4"
+  dependencies:
+    "@babel/code-frame": ^7.29.0
+    "@babel/core": ^7.25.2
+    "@babel/generator": ^7.29.1
+    "@babel/parser": ^7.29.0
+    "@babel/template": ^7.28.6
+    "@babel/traverse": ^7.29.0
+    "@babel/types": ^7.29.0
+    accepts: ^2.0.0
+    ci-info: ^2.0.0
+    connect: ^3.6.5
+    debug: ^4.4.0
+    error-stack-parser: ^2.0.6
+    flow-enums-runtime: ^0.0.6
+    graceful-fs: ^4.2.4
+    hermes-parser: 0.35.0
+    image-size: ^1.0.2
+    invariant: ^2.2.4
+    jest-worker: ^29.7.0
+    jsc-safe-url: ^0.2.2
+    lodash.throttle: ^4.1.1
+    metro-babel-transformer: 0.84.4
+    metro-cache: 0.84.4
+    metro-cache-key: 0.84.4
+    metro-config: 0.84.4
+    metro-core: 0.84.4
+    metro-file-map: 0.84.4
+    metro-resolver: 0.84.4
+    metro-runtime: 0.84.4
+    metro-source-map: 0.84.4
+    metro-symbolicate: 0.84.4
+    metro-transform-plugins: 0.84.4
+    metro-transform-worker: 0.84.4
+    mime-types: ^3.0.1
+    nullthrows: ^1.1.1
+    serialize-error: ^2.1.0
+    source-map: ^0.5.6
+    throat: ^5.0.0
+    ws: ^7.5.10
+    yargs: ^17.6.2
+  bin:
+    metro: src/cli.js
+  checksum: 343339ce00d033975beb116fe063b61421e40a815d8bbe1f78032d6ecb5613b89e68218af204dd168b9bdf66dcc4914b56ee8ee19997faa09c22b8413017dcc6
   languageName: node
   linkType: hard
 
@@ -15278,6 +15654,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: ^0.0.6
   checksum: 817cc83247508f6a17641924af5ccd793535e9376442ab8f9e59f7070cfb4830269540cacf79d036cdf087585810ced7dae3ea213c7f2dad73c2f198f1b676f9
+  languageName: node
+  linkType: hard
+
+"ob1@npm:0.84.4":
+  version: 0.84.4
+  resolution: "ob1@npm:0.84.4"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+  checksum: 15621cfa2d6bb196c5046031b3f85259735a245d9d7087f41758be3c31589c464e6eef53d94ec3d680fd8286ef08944782b9112f18d790a99421fbc7e311bb32
   languageName: node
   linkType: hard
 
@@ -15902,6 +16287,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 76b387b5157951422fa6049a96bdd1695e39dd126cd99df34d343638dc5cdb8bcdc83fff288c23eddcf7c26657c35e3173d4d5f488c4f28b889b314472e0a662
+  languageName: node
+  linkType: hard
+
 "pirates@npm:^4.0.1, pirates@npm:^4.0.4":
   version: 4.0.7
   resolution: "pirates@npm:4.0.7"
@@ -16423,20 +16815,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-harness@npm:1.0.0":
-  version: 1.0.0
-  resolution: "react-native-harness@npm:1.0.0"
+"react-native-harness@npm:1.1.0":
+  version: 1.1.0
+  resolution: "react-native-harness@npm:1.1.0"
   dependencies:
-    "@react-native-harness/babel-preset": 1.0.0
-    "@react-native-harness/cli": 1.0.0
-    "@react-native-harness/jest": 1.0.0
-    "@react-native-harness/metro": 1.0.0
-    "@react-native-harness/runtime": 1.0.0
+    "@react-native-harness/babel-preset": 1.1.0
+    "@react-native-harness/cli": 1.1.0
+    "@react-native-harness/jest": 1.1.0
+    "@react-native-harness/metro": 1.1.0
+    "@react-native-harness/runtime": 1.1.0
     tslib: ^2.3.0
   bin:
     harness: bin.js
     react-native-harness: bin.js
-  checksum: 737f1a13554cf1dcb199c93584c648703f47d15033b395c266cb611e2d09da7cefb7dbcc1501220eb2891097524d67d083cb197ec3d54e443452dfe56ba8decf
+  checksum: af01b4f1182388f211d5d7b67a5e0179ecd2855d9edc828b1120760c25f723800bec260a34f3d9715f288ddf5d9704dd1a4914fc843dadc4c8ba2bc4f6ebdc26
   languageName: node
   linkType: hard
 
@@ -16520,8 +16912,8 @@ __metadata:
     "@react-native-community/cli": 19.1.2
     "@react-native-community/cli-platform-android": 19.1.2
     "@react-native-community/cli-platform-ios": 19.1.2
-    "@react-native-harness/platform-android": 1.0.0
-    "@react-native-harness/platform-apple": 1.0.0
+    "@react-native-harness/platform-android": 1.1.0
+    "@react-native-harness/platform-apple": 1.1.0
     "@react-native-picker/picker": ^2.11.4
     "@react-native/babel-preset": 0.80.3
     "@react-native/metro-config": 0.80.3
@@ -16536,7 +16928,7 @@ __metadata:
     react-native: 0.80.3
     react-native-builder-bob: ^0.40.10
     react-native-gesture-handler: 2.29.1
-    react-native-harness: 1.0.0
+    react-native-harness: 1.1.0
     react-native-nitro-modules: 0.35.0
     react-native-reanimated: 4.1.5
     react-native-safe-area-context: ^5.4.0
@@ -16592,6 +16984,17 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 9b7d4cc2aed913a68abd725c51b41ae1d3c24abe3b47285f7a397d15c2f672710fa16819a8062ced3b60fb36e623d58d929a700863e1ae6e764a7f3ff981dd58
+  languageName: node
+  linkType: hard
+
+"react-native-url-polyfill@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "react-native-url-polyfill@npm:3.0.0"
+  dependencies:
+    whatwg-url-without-unicode: 8.0.0-3
+  peerDependencies:
+    react-native: "*"
+  checksum: 3d6e02b8c32933bca588b70e86c1b2981cd2d9f4055f7ce5ba5f321596ffae5ce89fea41af8d13eca7b4f29daf685406354c761696e5a4bdfb5698468e54a527
   languageName: node
   linkType: hard
 
@@ -18511,6 +18914,16 @@ __metadata:
     fdir: ^6.5.0
     picomatch: ^4.0.3
   checksum: 0e33b8babff966c6ab86e9b825a350a6a98a63700fa0bb7ae6cf36a7770a508892383adc272f7f9d17aaf46a9d622b455e775b9949a3f951eaaf5dfb26331d44
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.15":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
+  dependencies:
+    fdir: ^6.5.0
+    picomatch: ^4.0.4
+  checksum: db9d22ce1deb1095720a683c492cd5e80da0f71fed21ed697e2752f6f298edd8a1249dab197c86a26f001c180594a81bf532400fe519791ed2a2cb57b03bc337
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump react-native-harness and platform packages from 1.0.0 to 1.1.0.