### PR TITLE
chore(ci): free disk space before Android emulator tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/share/swift
+          df -h
+
       - name: Setup
         uses: ./.github/actions/setup
 


### PR DESCRIPTION
Remove unused tools (dotnet, haskell, CodeQL, powershell, swift) before the Android emulator step to prevent "No space left on device" when downloading the system image.

Seen in https://github.com/rive-app/rive-nitro-react-native/actions/runs/25857730656/job/75979638983