### PR TITLE
fix: stabilize trigger callbacks to prevent missed events on Android

### DIFF
--- a/src/hooks/useRiveProperty.ts
+++ b/src/hooks/useRiveProperty.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type ObservableProperty,
   type ViewModelInstance,
@@ -35,6 +35,12 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
   Error | null,
   P | undefined,
 ] {
+  // Store the callback in a ref so identity changes don't cause property
+  // disposal/re-creation. The listener always calls through the ref,
+  // ensuring the latest callback is invoked without re-subscribing.
+  const onPropertyEventOverrideRef = useRef(options.onPropertyEventOverride);
+  onPropertyEventOverrideRef.current = options.onPropertyEventOverride;
+
   const property = useDisposableMemo(
     () => {
       if (!viewModelInstance) return undefined;
@@ -44,7 +50,7 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
       ) as unknown as ObservableViewModelProperty<T>;
     },
     (p) => p?.dispose(),
-    [options, viewModelInstance, path]
+    [viewModelInstance, path]
   );
 
   // Always start undefined — the listener delivers the current value as its first emission.
@@ -75,12 +81,14 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
     // undefined → value without waiting for a property change.
     // (Legacy addListener does NOT emit on subscribe — only on changes.
     //  Experimental valueStream emits the current value as its first element.)
-    if (!options.onPropertyEventOverride) {
+    if (!onPropertyEventOverrideRef.current) {
       setValue(property.value);
     }
 
-    const removeListener = options.onPropertyEventOverride
-      ? property.addListener(options.onPropertyEventOverride)
+    const removeListener = onPropertyEventOverrideRef.current
+      ? property.addListener((...args: any[]) => {
+          onPropertyEventOverrideRef.current?.(...args);
+        })
       : property.addListener((newValue) => {
           setValue(newValue);
         });
@@ -93,7 +101,7 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
         // Native dispose() handles listener cleanup, so this is safe to ignore.
       }
     };
-  }, [options, property]);
+  }, [property]);
 
   // Set the value of the property (no-op if property isn't available yet).
   // Uses tracked `value` from state for updater functions — avoids a synchronous

--- a/src/hooks/useRiveTrigger.ts
+++ b/src/hooks/useRiveTrigger.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import {
   type ViewModelInstance,
   type ViewModelTriggerProperty,
@@ -26,18 +26,13 @@ export function useRiveTrigger(
 ): UseRiveTriggerResult {
   const { onTrigger } = params ?? {};
 
-  const triggerOptions = useMemo(
-    () => ({
-      getProperty: getTriggerProperty,
-      onPropertyEventOverride: onTrigger,
-    }),
-    [onTrigger]
-  );
-
   const [_, __, error, property] = useRiveProperty<
     ViewModelTriggerProperty,
     undefined
-  >(viewModelInstance, path, triggerOptions);
+  >(viewModelInstance, path, {
+    getProperty: getTriggerProperty,
+    onPropertyEventOverride: onTrigger,
+  });
 
   const trigger = useCallback(() => {
     if (property) {


### PR DESCRIPTION
Fixes #230

Unstable `onTrigger` callback references cause `useRiveTrigger` (and all property hooks) to silently stop receiving events on Android after re-renders.

The callback identity is now stored in a `useRef`, so the native property lifecycle is decoupled from callback changes. The property is only disposed/recreated when `viewModelInstance` or `path` changes.

<details>
<summary>Root cause and reproducer</summary>

### Root cause

`useDisposableMemo` disposes the old native property and creates a new one **during the render phase** (via ref mutation). When the callback identity changes (e.g. `onTrigger` without React Compiler memoization), `options` changes, which triggers this dispose/create cycle.

The problem: if a no-op state update (like `setError(null)` when error is already null) triggers a re-render that produces **identical JSX output**, React **bails out** — it runs the component function but skips the commit and effects. Since `useEffect` is skipped, the listener is never re-subscribed to the new property.

```
useDisposableMemo:  deps changed → DISPOSE old, CREATE new   ✅ runs (render phase)
useEffect:          deps changed → should re-subscribe...    ❌ skipped (bailout)
```

The property is orphaned — disposed old one is dead, new one has no listener. All subsequent trigger events are silently lost.

### Reproducer

```tsx
import { View, Text, Pressable } from 'react-native';
import {
  RiveView, useRiveFile, useRiveTrigger,
  useViewModelInstance, Fit,
} from '@rive-app/react-native';

export default function Issue230() {
  'use no memo'; // disable React Compiler → unstable callbacks

  const [triggerCount, setTriggerCount] = useState(0);
  const { riveFile } = useRiveFile(require('./rewards.riv'));
  const { instance } = useViewModelInstance(riveFile);

  // New reference every render — this is what triggers the bug
  const onTrigger = () => setTriggerCount((c) => c + 1);

  useRiveTrigger('Button/Pressed', instance, { onTrigger });

  return (
    <View>
      <Text>Triggers received: {triggerCount}</Text>
      {riveFile && instance && (
        <RiveView file={riveFile} fit={Fit.Contain} dataBind={instance}
          style={{ width: '100%', height: 200 }} />
      )}
    </View>
  );
}
// Tap the Rive button — first tap works, then triggers stop.
// On Android the trigger fires at the native level (chest opens)
// but the JS callback is never called after the bailout render.
```

### Actual logcat output (before fix)

```
[useRiveProperty] R2 CREATED property for "Button/Pressed": true
[useRiveProperty] R2 EFFECT RUN — SUBSCRIBING listener ✓
[useRiveProperty] R3 DISPOSING property for "Button/Pressed"
[useRiveProperty] R3 CREATED property for "Button/Pressed": true
                  ← no R3 EFFECT — React bailed out, listener never subscribed
```

</details>