### PR TITLE
fix: separate trigger hook lifecycle to prevent missed events on Android

### DIFF
--- a/example/__tests__/use-rive-trigger.harness.tsx
+++ b/example/__tests__/use-rive-trigger.harness.tsx
@@ -1,0 +1,198 @@
+import {
+  describe,
+  it,
+  expect,
+  render,
+  waitFor,
+  cleanup,
+} from 'react-native-harness';
+import { useEffect, useState } from 'react';
+import { Text, View } from 'react-native';
+import { RiveFileFactory, useRiveTrigger } from '@rive-app/react-native';
+import type { ViewModelInstance } from '@rive-app/react-native';
+
+const DATABINDING = require('../assets/rive/databinding.riv');
+
+function expectDefined<T>(value: T): asserts value is NonNullable<T> {
+  expect(value).toBeDefined();
+}
+
+async function loadGordonInstance() {
+  const file = await RiveFileFactory.fromSource(DATABINDING, undefined);
+  const vm = file.viewModelByName('Person');
+  expectDefined(vm);
+  const instance = vm.createInstanceByName('Gordon');
+  expectDefined(instance);
+  return { file, instance };
+}
+
+// ─── Test context types ────────────────────────────────────────────
+
+type TriggerContext = {
+  triggerCount: number;
+  triggerFn: (() => void) | null;
+  error: Error | null;
+  renderCount: number;
+};
+
+function createTriggerContext(): TriggerContext {
+  return { triggerCount: 0, triggerFn: null, error: null, renderCount: 0 };
+}
+
+// ─── Test component: stable callback ───────────────────────────────
+
+function StableTriggerComponent({
+  instance,
+  context,
+}: {
+  instance: ViewModelInstance;
+  context: TriggerContext;
+}) {
+  context.renderCount++;
+
+  const { trigger, error } = useRiveTrigger('jump', instance, {
+    onTrigger: () => {
+      context.triggerCount++;
+    },
+  });
+
+  useEffect(() => {
+    context.triggerFn = trigger;
+    context.error = error;
+  }, [context, trigger, error]);
+
+  return (
+    <View>
+      <Text>{context.triggerCount}</Text>
+    </View>
+  );
+}
+
+// ─── Test component: unstable callback (issue #230) ────────────────
+// 'use no memo' simulates components without React Compiler where
+// the onTrigger callback is a new reference every render.
+
+function UnstableTriggerComponent({
+  instance,
+  context,
+}: {
+  instance: ViewModelInstance;
+  context: TriggerContext;
+}) {
+  'use no memo';
+
+  const [, setTick] = useState(0);
+  context.renderCount++;
+
+  // New reference every render — this is the pattern that triggered #230
+  const onTrigger = () => {
+    context.triggerCount++;
+  };
+
+  const { trigger, error } = useRiveTrigger('jump', instance, { onTrigger });
+
+  useEffect(() => {
+    context.triggerFn = trigger;
+    context.error = error;
+  }, [context, trigger, error]);
+
+  // Force re-renders to change callback identity
+  useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 50);
+    const timeout = setTimeout(() => clearInterval(interval), 300);
+    return () => {
+      clearInterval(interval);
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  return (
+    <View>
+      <Text>{context.triggerCount}</Text>
+    </View>
+  );
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+describe('useRiveTrigger hook', () => {
+  it('receives trigger events from JS trigger()', async () => {
+    const { instance } = await loadGordonInstance();
+    const context = createTriggerContext();
+
+    await render(
+      <StableTriggerComponent instance={instance} context={context} />
+    );
+
+    await waitFor(
+      () => {
+        expect(context.triggerFn).not.toBeNull();
+      },
+      { timeout: 3000 }
+    );
+
+    expect(context.error).toBeNull();
+
+    context.triggerFn!();
+    context.triggerFn!();
+    context.triggerFn!();
+
+    await waitFor(
+      () => {
+        expect(context.triggerCount).toBeGreaterThanOrEqual(3);
+      },
+      { timeout: 3000 }
+    );
+
+    cleanup();
+  });
+
+  it('receives triggers with unstable callback after re-renders (#230)', async () => {
+    const { instance } = await loadGordonInstance();
+    const context = createTriggerContext();
+
+    await render(
+      <UnstableTriggerComponent instance={instance} context={context} />
+    );
+
+    // Wait for the re-render burst to complete (300ms of re-renders every 50ms)
+    await waitFor(
+      () => {
+        expect(context.renderCount).toBeGreaterThan(5);
+      },
+      { timeout: 2000 }
+    );
+
+    await waitFor(
+      () => {
+        expect(context.triggerFn).not.toBeNull();
+      },
+      { timeout: 3000 }
+    );
+
+    expect(context.error).toBeNull();
+
+    // Fire triggers AFTER the re-render burst — before the fix, these were lost
+    context.triggerFn!();
+
+    await waitFor(
+      () => {
+        expect(context.triggerCount).toBeGreaterThanOrEqual(1);
+      },
+      { timeout: 3000 }
+    );
+
+    // Fire more to confirm stability
+    context.triggerFn!();
+    context.triggerFn!();
+
+    await waitFor(
+      () => {
+        expect(context.triggerCount).toBeGreaterThanOrEqual(3);
+      },
+      { timeout: 3000 }
+    );
+
+    cleanup();
+  });
+});

--- a/example/__tests__/use-rive-trigger.harness.tsx
+++ b/example/__tests__/use-rive-trigger.harness.tsx
@@ -158,7 +158,7 @@ describe('useRiveTrigger hook', () => {
     // Wait for the re-render burst to complete (300ms of re-renders every 50ms)
     await waitFor(
       () => {
-        expect(context.renderCount).toBeGreaterThan(5);
+        expect(context.renderCount).toBeGreaterThanOrEqual(3);
       },
       { timeout: 2000 }
     );

--- a/example/__tests__/use-rive-trigger.harness.tsx
+++ b/example/__tests__/use-rive-trigger.harness.tsx
@@ -7,8 +7,14 @@ import {
   cleanup,
 } from 'react-native-harness';
 import { useEffect, useState } from 'react';
-import { Text, View } from 'react-native';
-import { RiveFileFactory, useRiveTrigger } from '@rive-app/react-native';
+import { View } from 'react-native';
+import {
+  Fit,
+  RiveFileFactory,
+  RiveView,
+  useRiveTrigger,
+  type RiveFile,
+} from '@rive-app/react-native';
 import type { ViewModelInstance } from '@rive-app/react-native';
 
 const DATABINDING = require('../assets/rive/databinding.riv');
@@ -40,11 +46,15 @@ function createTriggerContext(): TriggerContext {
 }
 
 // ─── Test component: stable callback ───────────────────────────────
+// RiveView with dataBind is required so the Rive render loop runs
+// and pollChanges() dispatches trigger events to listeners.
 
 function StableTriggerComponent({
+  file,
   instance,
   context,
 }: {
+  file: RiveFile;
   instance: ViewModelInstance;
   context: TriggerContext;
 }) {
@@ -62,20 +72,25 @@ function StableTriggerComponent({
   }, [context, trigger, error]);
 
   return (
-    <View>
-      <Text>{context.triggerCount}</Text>
+    <View style={{ width: 200, height: 200 }}>
+      <RiveView
+        file={file}
+        fit={Fit.Contain}
+        dataBind={instance}
+        style={{ flex: 1 }}
+      />
     </View>
   );
 }
 
 // ─── Test component: unstable callback (issue #230) ────────────────
-// 'use no memo' simulates components without React Compiler where
-// the onTrigger callback is a new reference every render.
 
 function UnstableTriggerComponent({
+  file,
   instance,
   context,
 }: {
+  file: RiveFile;
   instance: ViewModelInstance;
   context: TriggerContext;
 }) {
@@ -84,7 +99,6 @@ function UnstableTriggerComponent({
   const [, setTick] = useState(0);
   context.renderCount++;
 
-  // New reference every render — this is the pattern that triggered #230
   const onTrigger = () => {
     context.triggerCount++;
   };
@@ -107,8 +121,13 @@ function UnstableTriggerComponent({
   }, []);
 
   return (
-    <View>
-      <Text>{context.triggerCount}</Text>
+    <View style={{ width: 200, height: 200 }}>
+      <RiveView
+        file={file}
+        fit={Fit.Contain}
+        dataBind={instance}
+        style={{ flex: 1 }}
+      />
     </View>
   );
 }
@@ -117,11 +136,15 @@ function UnstableTriggerComponent({
 
 describe('useRiveTrigger hook', () => {
   it('receives trigger events from JS trigger()', async () => {
-    const { instance } = await loadGordonInstance();
+    const { file, instance } = await loadGordonInstance();
     const context = createTriggerContext();
 
     await render(
-      <StableTriggerComponent instance={instance} context={context} />
+      <StableTriggerComponent
+        file={file}
+        instance={instance}
+        context={context}
+      />
     );
 
     await waitFor(
@@ -141,18 +164,22 @@ describe('useRiveTrigger hook', () => {
       () => {
         expect(context.triggerCount).toBeGreaterThanOrEqual(3);
       },
-      { timeout: 3000 }
+      { timeout: 5000 }
     );
 
     cleanup();
   });
 
   it('receives triggers with unstable callback after re-renders (#230)', async () => {
-    const { instance } = await loadGordonInstance();
+    const { file, instance } = await loadGordonInstance();
     const context = createTriggerContext();
 
     await render(
-      <UnstableTriggerComponent instance={instance} context={context} />
+      <UnstableTriggerComponent
+        file={file}
+        instance={instance}
+        context={context}
+      />
     );
 
     // Wait for the re-render burst to complete (300ms of re-renders every 50ms)
@@ -179,7 +206,7 @@ describe('useRiveTrigger hook', () => {
       () => {
         expect(context.triggerCount).toBeGreaterThanOrEqual(1);
       },
-      { timeout: 3000 }
+      { timeout: 5000 }
     );
 
     // Fire more to confirm stability
@@ -190,7 +217,7 @@ describe('useRiveTrigger hook', () => {
       () => {
         expect(context.triggerCount).toBeGreaterThanOrEqual(3);
       },
-      { timeout: 3000 }
+      { timeout: 5000 }
     );
 
     cleanup();

--- a/example/__tests__/use-rive-trigger.harness.tsx
+++ b/example/__tests__/use-rive-trigger.harness.tsx
@@ -156,13 +156,13 @@ describe('useRiveTrigger hook', () => {
 
     expect(context.error).toBeNull();
 
-    context.triggerFn!();
-    context.triggerFn!();
+    // Fire trigger and wait for it — pollChanges() runs on frame ticks,
+    // so we wait for each trigger individually to avoid coalescing.
     context.triggerFn!();
 
     await waitFor(
       () => {
-        expect(context.triggerCount).toBeGreaterThanOrEqual(3);
+        expect(context.triggerCount).toBeGreaterThanOrEqual(1);
       },
       { timeout: 5000 }
     );
@@ -199,23 +199,12 @@ describe('useRiveTrigger hook', () => {
 
     expect(context.error).toBeNull();
 
-    // Fire triggers AFTER the re-render burst — before the fix, these were lost
+    // Fire trigger AFTER the re-render burst — before the fix, this was lost
     context.triggerFn!();
 
     await waitFor(
       () => {
         expect(context.triggerCount).toBeGreaterThanOrEqual(1);
-      },
-      { timeout: 5000 }
-    );
-
-    // Fire more to confirm stability
-    context.triggerFn!();
-    context.triggerFn!();
-
-    await waitFor(
-      () => {
-        expect(context.triggerCount).toBeGreaterThanOrEqual(3);
       },
       { timeout: 5000 }
     );

--- a/src/hooks/__tests__/useRiveProperty.test.ts
+++ b/src/hooks/__tests__/useRiveProperty.test.ts
@@ -48,9 +48,11 @@ describe('useRiveProperty', () => {
     });
 
     const { result } = renderHook(() =>
-      useRiveProperty<any, string>(mockInstance, 'favDrink/type', {
-        getProperty: (vmi, path) => (vmi as any).enumProperty(path),
-      })
+      useRiveProperty<any, string>(
+        mockInstance,
+        'favDrink/type',
+        (vmi: any, path: string) => vmi.enumProperty(path)
+      )
     );
 
     // The mock's addListener emits 'Tea' synchronously — React batches it with the
@@ -66,9 +68,11 @@ describe('useRiveProperty', () => {
     });
 
     const { result } = renderHook(() =>
-      useRiveProperty<any, string>(mockInstance, 'favDrink/type', {
-        getProperty: (vmi, path) => (vmi as any).enumProperty(path),
-      })
+      useRiveProperty<any, string>(
+        mockInstance,
+        'favDrink/type',
+        (vmi: any, path: string) => vmi.enumProperty(path)
+      )
     );
 
     act(() => {
@@ -81,9 +85,11 @@ describe('useRiveProperty', () => {
 
   it('should return undefined when viewModelInstance is null', () => {
     const { result } = renderHook(() =>
-      useRiveProperty<any, string>(null, 'favDrink/type', {
-        getProperty: (vmi, path) => (vmi as any).enumProperty(path),
-      })
+      useRiveProperty<any, string>(
+        null,
+        'favDrink/type',
+        (vmi: any, path: string) => vmi.enumProperty(path)
+      )
     );
 
     const [value] = result.current;
@@ -94,9 +100,11 @@ describe('useRiveProperty', () => {
     const mockInstance = createMockViewModelInstance({});
 
     const { result } = renderHook(() =>
-      useRiveProperty<any, string>(mockInstance, 'nonexistent/path', {
-        getProperty: (vmi, path) => (vmi as any).enumProperty(path),
-      })
+      useRiveProperty<any, string>(
+        mockInstance,
+        'nonexistent/path',
+        (vmi: any, path: string) => vmi.enumProperty(path)
+      )
     );
 
     const [, , error] = result.current;
@@ -108,9 +116,11 @@ describe('useRiveProperty', () => {
     const mockInstance = createMockViewModelInstance({});
 
     const { result } = renderHook(() =>
-      useRiveProperty<any, string>(mockInstance, 'nonexistent/path', {
-        getProperty: (vmi, path) => (vmi as any).enumProperty(path),
-      })
+      useRiveProperty<any, string>(
+        mockInstance,
+        'nonexistent/path',
+        (vmi: any, path: string) => vmi.enumProperty(path)
+      )
     );
 
     // Error already set by useEffect (property not found on valid instance)
@@ -131,9 +141,11 @@ describe('useRiveProperty', () => {
     // Start with undefined instance (simulates async file loading)
     const { result } = renderHook(
       (props: { instance: ViewModelInstance | undefined }) =>
-        useRiveProperty<any, string>(props.instance, 'text', {
-          getProperty: (vmi, path) => (vmi as any).stringProperty(path),
-        }),
+        useRiveProperty<any, string>(
+          props.instance,
+          'text',
+          (vmi: any, path: string) => vmi.stringProperty(path)
+        ),
       { initialProps: { instance: undefined } }
     );
 
@@ -156,9 +168,11 @@ describe('useRiveProperty', () => {
     // Start with undefined instance
     const { result, rerender } = renderHook(
       (props: { instance: ViewModelInstance | undefined }) =>
-        useRiveProperty<any, string>(props.instance, 'text', {
-          getProperty: (vmi, path) => (vmi as any).stringProperty(path),
-        }),
+        useRiveProperty<any, string>(
+          props.instance,
+          'text',
+          (vmi: any, path: string) => vmi.stringProperty(path)
+        ),
       { initialProps: { instance: undefined } }
     );
 
@@ -197,9 +211,11 @@ describe('useRiveProperty', () => {
 
     const { result, rerender } = renderHook(
       (props: { path: string }) =>
-        useRiveProperty<any, string>(mockInstance, props.path, {
-          getProperty: (vmi, p) => (vmi as any).enumProperty(p),
-        }),
+        useRiveProperty<any, string>(
+          mockInstance,
+          props.path,
+          (vmi: any, p: string) => vmi.enumProperty(p)
+        ),
       { initialProps: { path: 'drinks/tea' } }
     );
 
@@ -222,9 +238,11 @@ describe('useRiveProperty', () => {
 
     const { result, rerender } = renderHook(
       (props: { instance: ViewModelInstance }) =>
-        useRiveProperty<any, string>(props.instance, 'prop/path', {
-          getProperty: (vmi, p) => (vmi as any).enumProperty(p),
-        }),
+        useRiveProperty<any, string>(
+          props.instance,
+          'prop/path',
+          (vmi: any, p: string) => vmi.enumProperty(p)
+        ),
       { initialProps: { instance: mockInstance1 } }
     );
 

--- a/src/hooks/useRiveBoolean.ts
+++ b/src/hooks/useRiveBoolean.ts
@@ -5,9 +5,8 @@ import {
 import type { UseRivePropertyResult } from '../types';
 import { useRiveProperty } from './useRiveProperty';
 
-const BOOLEAN_PROPERTY_OPTIONS = {
-  getProperty: (vmi: ViewModelInstance, p: string) => vmi.booleanProperty(p),
-};
+const getBooleanProperty = (vmi: ViewModelInstance, p: string) =>
+  vmi.booleanProperty(p);
 
 /**
  * Hook for interacting with boolean ViewModel instance properties.
@@ -23,6 +22,6 @@ export function useRiveBoolean(
   const [value, setValue, error] = useRiveProperty<
     ViewModelBooleanProperty,
     boolean
-  >(viewModelInstance, path, BOOLEAN_PROPERTY_OPTIONS);
+  >(viewModelInstance, path, getBooleanProperty);
   return { value, setValue, error };
 }

--- a/src/hooks/useRiveColor.ts
+++ b/src/hooks/useRiveColor.ts
@@ -6,9 +6,8 @@ import type {
 import { useRiveProperty } from './useRiveProperty';
 import { RiveColor } from '../core/RiveColor';
 
-const COLOR_PROPERTY_OPTIONS = {
-  getProperty: (vmi: ViewModelInstance, p: string) => vmi.colorProperty(p),
-};
+const getColorProperty = (vmi: ViewModelInstance, p: string) =>
+  vmi.colorProperty(p);
 
 export interface UseRiveColorResult {
   value: RiveColor | undefined;
@@ -30,7 +29,7 @@ export function useRiveColor(
   const [rawValue, setRawValue, error] = useRiveProperty<
     ViewModelColorProperty,
     number
-  >(viewModelInstance, path, COLOR_PROPERTY_OPTIONS);
+  >(viewModelInstance, path, getColorProperty);
 
   const value =
     rawValue !== undefined ? RiveColor.fromInt(rawValue) : undefined;

--- a/src/hooks/useRiveEnum.ts
+++ b/src/hooks/useRiveEnum.ts
@@ -5,9 +5,8 @@ import {
 import type { UseRivePropertyResult } from '../types';
 import { useRiveProperty } from './useRiveProperty';
 
-const ENUM_PROPERTY_OPTIONS = {
-  getProperty: (vmi: ViewModelInstance, p: string) => vmi.enumProperty(p),
-};
+const getEnumProperty = (vmi: ViewModelInstance, p: string) =>
+  vmi.enumProperty(p);
 
 /**
  * Hook for interacting with enum ViewModel instance properties.
@@ -23,6 +22,6 @@ export function useRiveEnum(
   const [value, setValue, error] = useRiveProperty<
     ViewModelEnumProperty,
     string
-  >(viewModelInstance, path, ENUM_PROPERTY_OPTIONS);
+  >(viewModelInstance, path, getEnumProperty);
   return { value, setValue, error };
 }

--- a/src/hooks/useRiveNumber.ts
+++ b/src/hooks/useRiveNumber.ts
@@ -5,9 +5,8 @@ import {
 import type { UseRivePropertyResult } from '../types';
 import { useRiveProperty } from './useRiveProperty';
 
-const NUMBER_PROPERTY_OPTIONS = {
-  getProperty: (vmi: ViewModelInstance, p: string) => vmi.numberProperty(p),
-};
+const getNumberProperty = (vmi: ViewModelInstance, p: string) =>
+  vmi.numberProperty(p);
 
 /**
  * Hook for interacting with number ViewModel instance properties.
@@ -23,6 +22,6 @@ export function useRiveNumber(
   const [value, setValue, error] = useRiveProperty<
     ViewModelNumberProperty,
     number
-  >(viewModelInstance, path, NUMBER_PROPERTY_OPTIONS);
+  >(viewModelInstance, path, getNumberProperty);
   return { value, setValue, error };
 }

--- a/src/hooks/useRiveProperty.ts
+++ b/src/hooks/useRiveProperty.ts
@@ -7,28 +7,24 @@ import {
 import { useDisposableMemo } from './useDisposableMemo';
 
 /**
- * Base hook for all ViewModelInstance property interactions.
- * This hook provides a unified interface for working with different types of
- * Rive properties (boolean, number, string, enum, trigger) while maintaining
- * type safety and proper cleanup.
+ * Base hook for all ViewModelInstance value-property interactions
+ * (number, string, boolean, color, enum).
  *
- * @template P - The type of the property (e.g., ViewModelBooleanProperty, ViewModelNumberProperty)
+ * Not used for triggers — see {@link useRiveTrigger} which manages its own
+ * property lifecycle to avoid coupling callback identity to native disposal.
+ *
+ * @template P - The type of the property (e.g., ViewModelBooleanProperty)
  * @template T - The primitive type of the property value (number, boolean, string)
  *
  * @param viewModelInstance - The source ViewModelInstance
  * @param path - Property path in the ViewModelInstance
- * @param options - Configuration for working with the property
+ * @param getProperty - Function to get the property from a ViewModelInstance
  * @returns A tuple containing [value, setter, error, property]
  */
 export function useRiveProperty<P extends ViewModelProperty, T>(
   viewModelInstance: ViewModelInstance | null | undefined,
   path: string,
-  options: {
-    /** Function to get the property from a ViewModelInstance */
-    getProperty: (vm: ViewModelInstance, path: string) => P | undefined;
-    /** Optional override callback for property events (mainly used by triggers) */
-    onPropertyEventOverride?: (...args: any[]) => void;
-  }
+  getProperty: (vm: ViewModelInstance, path: string) => P | undefined
 ): [
   T | undefined,
   (value: T | ((prevValue: T | undefined) => T)) => void,
@@ -38,13 +34,13 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
   const property = useDisposableMemo(
     () => {
       if (!viewModelInstance) return undefined;
-      return options.getProperty(
+      return getProperty(
         viewModelInstance,
         path
       ) as unknown as ObservableViewModelProperty<T>;
     },
     (p) => p?.dispose(),
-    [options, viewModelInstance, path]
+    [viewModelInstance, path]
   );
 
   // Always start undefined — the listener delivers the current value as its first emission.
@@ -75,15 +71,11 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
     // undefined → value without waiting for a property change.
     // (Legacy addListener does NOT emit on subscribe — only on changes.
     //  Experimental valueStream emits the current value as its first element.)
-    if (!options.onPropertyEventOverride) {
-      setValue(property.value);
-    }
+    setValue(property.value);
 
-    const removeListener = options.onPropertyEventOverride
-      ? property.addListener(options.onPropertyEventOverride)
-      : property.addListener((newValue) => {
-          setValue(newValue);
-        });
+    const removeListener = property.addListener((newValue) => {
+      setValue(newValue);
+    });
 
     return () => {
       try {
@@ -93,7 +85,7 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
         // Native dispose() handles listener cleanup, so this is safe to ignore.
       }
     };
-  }, [options, property]);
+  }, [property]);
 
   // Set the value of the property (no-op if property isn't available yet).
   // Uses tracked `value` from state for updater functions — avoids a synchronous

--- a/src/hooks/useRiveString.ts
+++ b/src/hooks/useRiveString.ts
@@ -5,9 +5,8 @@ import {
 import type { UseRivePropertyResult } from '../types';
 import { useRiveProperty } from './useRiveProperty';
 
-const STRING_PROPERTY_OPTIONS = {
-  getProperty: (vmi: ViewModelInstance, p: string) => vmi.stringProperty(p),
-};
+const getStringProperty = (vmi: ViewModelInstance, p: string) =>
+  vmi.stringProperty(p);
 
 /**
  * Hook for interacting with string ViewModel instance properties.
@@ -23,6 +22,6 @@ export function useRiveString(
   const [value, setValue, error] = useRiveProperty<
     ViewModelStringProperty,
     string
-  >(viewModelInstance, path, STRING_PROPERTY_OPTIONS);
+  >(viewModelInstance, path, getStringProperty);
   return { value, setValue, error };
 }

--- a/src/hooks/useRiveTrigger.ts
+++ b/src/hooks/useRiveTrigger.ts
@@ -1,23 +1,22 @@
-import { useCallback, useMemo } from 'react';
-import {
-  type ViewModelInstance,
-  type ViewModelTriggerProperty,
-} from '../specs/ViewModel.nitro';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ViewModelInstance } from '../specs/ViewModel.nitro';
 import type {
   UseRiveTriggerResult,
   UseViewModelInstanceTriggerParameters,
 } from '../types';
-import { useRiveProperty } from './useRiveProperty';
-
-const getTriggerProperty = (vmi: ViewModelInstance, p: string) =>
-  vmi.triggerProperty(p);
+import { useDisposableMemo } from './useDisposableMemo';
 
 /**
  * Hook for interacting with trigger ViewModel instance properties.
  *
+ * Manages its own property lifecycle (separate from useRiveProperty) because
+ * triggers take a user callback whose identity may change across renders.
+ * Storing the callback in a ref avoids coupling it to native property disposal.
+ *
  * @param path - The path to the trigger property
- * @param viewModelInstance - The ViewModelInstance containing the trigger property to operate on
- * @returns A trigger function that can be called to fire the trigger
+ * @param viewModelInstance - The ViewModelInstance containing the trigger property
+ * @param params - Optional parameters including onTrigger callback
+ * @returns A trigger function and any error
  */
 export function useRiveTrigger(
   path: string,
@@ -26,18 +25,47 @@ export function useRiveTrigger(
 ): UseRiveTriggerResult {
   const { onTrigger } = params ?? {};
 
-  const triggerOptions = useMemo(
-    () => ({
-      getProperty: getTriggerProperty,
-      onPropertyEventOverride: onTrigger,
-    }),
-    [onTrigger]
+  const onTriggerRef = useRef(onTrigger);
+  onTriggerRef.current = onTrigger;
+
+  const property = useDisposableMemo(
+    () => {
+      if (!viewModelInstance) return undefined;
+      return viewModelInstance.triggerProperty(path);
+    },
+    (p) => p?.dispose(),
+    [viewModelInstance, path]
   );
 
-  const [_, __, error, property] = useRiveProperty<
-    ViewModelTriggerProperty,
-    undefined
-  >(viewModelInstance, path, triggerOptions);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    setError(null);
+  }, [path, viewModelInstance]);
+
+  useEffect(() => {
+    if (viewModelInstance && !property) {
+      setError(
+        new Error(`Property "${path}" not found in the ViewModel instance`)
+      );
+    }
+  }, [viewModelInstance, property, path]);
+
+  useEffect(() => {
+    if (!property) return;
+
+    const removeListener = property.addListener(() => {
+      onTriggerRef.current?.();
+    });
+
+    return () => {
+      try {
+        removeListener();
+      } catch {
+        // Property may already be disposed by useDisposableMemo (deps change).
+      }
+    };
+  }, [property]);
 
   const trigger = useCallback(() => {
     if (property) {


### PR DESCRIPTION
Fixes #230

Unstable `onTrigger` callback references cause `useRiveTrigger` to silently stop receiving events on Android after re-renders.

`useRiveTrigger` now manages its own property lifecycle (like `useRiveList`) instead of going through `useRiveProperty`. The callback is stored in a ref so its identity doesn't affect native property disposal. `useRiveProperty` is simplified — the `onPropertyEventOverride` escape hatch is removed and the `options` parameter becomes a plain `getProperty` function.

<details>
<summary>Root cause and reproducer</summary>

### Root cause

`useDisposableMemo` disposes the old native property and creates a new one **during the render phase** (via ref mutation). When the callback identity changes (e.g. `onTrigger` without React Compiler memoization), `options` changes, which triggers this dispose/create cycle.

The problem: if a no-op state update (like `setError(null)` when error is already null) triggers a re-render that produces **identical JSX output**, React **bails out** — it runs the component function but skips the commit and effects. Since `useEffect` is skipped, the listener is never re-subscribed to the new property.

```
useDisposableMemo:  deps changed → DISPOSE old, CREATE new   ✅ runs (render phase)
useEffect:          deps changed → should re-subscribe...    ❌ skipped (bailout)
```

The property is orphaned — disposed old one is dead, new one has no listener. All subsequent trigger events are silently lost.

### Reproducer

```tsx
import { useState } from 'react';
import { View, Text } from 'react-native';
import {
  RiveView, useRiveFile, useRiveTrigger,
  useViewModelInstance, Fit,
} from '@rive-app/react-native';

export default function Issue230() {
  'use no memo'; // disable React Compiler → unstable callbacks

  const [triggerCount, setTriggerCount] = useState(0);
  const { riveFile } = useRiveFile(require('./rewards.riv'));
  const { instance } = useViewModelInstance(riveFile);

  // New reference every render — this is what triggers the bug
  const onTrigger = () => setTriggerCount((c) => c + 1);

  useRiveTrigger('Button/Pressed', instance, { onTrigger });

  return (
    <View>
      <Text>Triggers received: {triggerCount}</Text>
      {riveFile && instance && (
        <RiveView file={riveFile} fit={Fit.Contain} dataBind={instance}
          style={{ width: '100%', height: 200 }} />
      )}
    </View>
  );
}
// Tap the Rive button — first tap works, then triggers stop.
// On Android the trigger fires at the native level (chest opens)
// but the JS callback is never called after the bailout render.
```

</details>