### PR TITLE
fix(android): allow overriding CMake version for Windows long-path builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ export default {
 
 ## Building on Windows (CMake long-path failures)
 
-On Windows, the Android build can fail with `ninja: error: mkdir(CMakeFiles/rive.dir/...): No such file or directory` due to the Windows `MAX_PATH` (260 character) limit. This is a [known issue across React Native libraries that use CMake](https://docs.swmansion.com/react-native-reanimated/docs/guides/building-on-windows/). Set `CMAKE_VERSION=3.31.6` before building — see the Reanimated docs for full setup instructions.
+On Windows, the Android build can fail with `ninja: error: mkdir(CMakeFiles/rive.dir/...): No such file or directory` due to the Windows `MAX_PATH` (260-character) limit. This is a [known issue across React Native libraries that use CMake](https://docs.swmansion.com/react-native-reanimated/docs/guides/building-on-windows/). Set `CMAKE_VERSION` to a newer version (e.g. `3.31.6`) before building — see the Reanimated docs for full setup instructions.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,49 @@ export default {
 
 </details>
 
+## Building on Windows (CMake long-path failures)
+
+On Windows, the Android build can fail during the native (CMake/Ninja) step with an error such as:
+
+```
+ninja: error: mkdir(CMakeFiles/rive.dir/.../nitrogen/generated/android): No such file or directory
+```
+
+This is the Windows `MAX_PATH` (260 character) limit: the NDK's default CMake (3.22.1) cannot create the deeply-nested object-file directories used for Rive's generated sources. A newer CMake (3.31.6+) handles long paths correctly.
+
+You can override the CMake version used to build this module without editing `node_modules`. Set either the `CMAKE_VERSION` environment variable or the `Rive_CmakeVersion` Gradle property. Leaving both unset preserves the default behavior.
+
+**Vanilla React Native** - add to `android/gradle.properties`:
+
+```properties
+Rive_CmakeVersion=3.31.6
+```
+
+**Expo** - use an inline config plugin in your `app.config.ts`:
+
+```typescript
+import { withGradleProperties } from '@expo/config-plugins';
+
+export default {
+  expo: {
+    // ... other config
+    plugins: [
+      (config) =>
+        withGradleProperties(config, (config) => {
+          config.modResults.push({
+            type: 'property',
+            key: 'Rive_CmakeVersion',
+            value: '3.31.6',
+          });
+          return config;
+        }),
+    ],
+  },
+};
+```
+
+Make sure the requested CMake version is installed (`sdkmanager "cmake;3.31.6"`), or that SDK licenses are accepted so the Android Gradle plugin can download it. Additional Windows long-path mitigations: enable [long-path support in the Windows registry](https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later), use `subst` to shorten the project path, and ensure Ninja ≥ 1.12.0.
+
 ## Error Handling
 
 All Rive operations can be wrapped in try/catch blocks for error handling, for example, loading a file:

--- a/README.md
+++ b/README.md
@@ -133,46 +133,9 @@ export default {
 
 ## Building on Windows (CMake long-path failures)
 
-On Windows, the Android build can fail during the native (CMake/Ninja) step with an error such as:
+On Windows, the Android build can fail with `ninja: error: mkdir(CMakeFiles/rive.dir/...): No such file or directory` due to the Windows `MAX_PATH` (260 character) limit. This is a [known issue across React Native libraries that use CMake](https://docs.swmansion.com/react-native-reanimated/docs/guides/building-on-windows/) — the Reanimated docs cover the general mitigations (newer CMake, long-path registry key, shorter project paths).
 
-```
-ninja: error: mkdir(CMakeFiles/rive.dir/.../nitrogen/generated/android): No such file or directory
-```
-
-This is the Windows `MAX_PATH` (260 character) limit: the NDK's default CMake (3.22.1) cannot create the deeply-nested object-file directories used for Rive's generated sources. A newer CMake (3.31.6+) handles long paths correctly.
-
-You can override the CMake version used to build this module without editing `node_modules`. Set either the `CMAKE_VERSION` environment variable or the `Rive_CmakeVersion` Gradle property. Leaving both unset preserves the default behavior.
-
-**Vanilla React Native** - add to `android/gradle.properties`:
-
-```properties
-Rive_CmakeVersion=3.31.6
-```
-
-**Expo** - use an inline config plugin in your `app.config.ts`:
-
-```typescript
-import { withGradleProperties } from '@expo/config-plugins';
-
-export default {
-  expo: {
-    // ... other config
-    plugins: [
-      (config) =>
-        withGradleProperties(config, (config) => {
-          config.modResults.push({
-            type: 'property',
-            key: 'Rive_CmakeVersion',
-            value: '3.31.6',
-          });
-          return config;
-        }),
-    ],
-  },
-};
-```
-
-Make sure the requested CMake version is installed (`sdkmanager "cmake;3.31.6"`), or that SDK licenses are accepted so the Android Gradle plugin can download it. Additional Windows long-path mitigations: enable [long-path support in the Windows registry](https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation#enable-long-paths-in-windows-10-version-1607-and-later), use `subst` to shorten the project path, and ensure Ninja ≥ 1.12.0.
+For this library specifically, you can override the CMake version via the `CMAKE_VERSION` environment variable or a `Rive_CmakeVersion` Gradle property (add `Rive_CmakeVersion=3.31.6` to `android/gradle.properties`). Make sure the version is installed: `sdkmanager "cmake;3.31.6"`.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,7 @@ export default {
 
 ## Building on Windows (CMake long-path failures)
 
-On Windows, the Android build can fail with `ninja: error: mkdir(CMakeFiles/rive.dir/...): No such file or directory` due to the Windows `MAX_PATH` (260 character) limit. This is a [known issue across React Native libraries that use CMake](https://docs.swmansion.com/react-native-reanimated/docs/guides/building-on-windows/) — the Reanimated docs cover the general mitigations (newer CMake, long-path registry key, shorter project paths).
-
-For this library specifically, you can override the CMake version via the `CMAKE_VERSION` environment variable or a `Rive_CmakeVersion` Gradle property (add `Rive_CmakeVersion=3.31.6` to `android/gradle.properties`). Make sure the version is installed: `sdkmanager "cmake;3.31.6"`.
+On Windows, the Android build can fail with `ninja: error: mkdir(CMakeFiles/rive.dir/...): No such file or directory` due to the Windows `MAX_PATH` (260 character) limit. This is a [known issue across React Native libraries that use CMake](https://docs.swmansion.com/react-native-reanimated/docs/guides/building-on-windows/). Set `CMAKE_VERSION=3.31.6` before building — see the Reanimated docs for full setup instructions.
 
 ## Error Handling
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,11 +69,10 @@ android {
   externalNativeBuild {
     cmake {
       path "CMakeLists.txt"
-      // Optional CMake version override. The NDK default (3.22.1) fails on
-      // Windows when object-file paths exceed MAX_PATH (260 chars); a newer
-      // CMake (e.g. 3.31.6) handles long paths correctly.
-      def cmakeVersionOverride = System.getenv("CMAKE_VERSION") ?:
-        (project.hasProperty("Rive_CmakeVersion") ? project.property("Rive_CmakeVersion") : null)
+      // On Windows the NDK default CMake (3.22.1) fails when object-file
+      // paths exceed MAX_PATH (260 chars). Set CMAKE_VERSION=3.31.6 to fix.
+      // See: https://docs.swmansion.com/react-native-reanimated/docs/guides/building-on-windows/
+      def cmakeVersionOverride = System.getenv("CMAKE_VERSION")
       if (cmakeVersionOverride) {
         version cmakeVersionOverride
       }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -69,6 +69,14 @@ android {
   externalNativeBuild {
     cmake {
       path "CMakeLists.txt"
+      // Optional CMake version override. The NDK default (3.22.1) fails on
+      // Windows when object-file paths exceed MAX_PATH (260 chars); a newer
+      // CMake (e.g. 3.31.6) handles long paths correctly.
+      def cmakeVersionOverride = System.getenv("CMAKE_VERSION") ?:
+        (project.hasProperty("Rive_CmakeVersion") ? project.property("Rive_CmakeVersion") : null)
+      if (cmakeVersionOverride) {
+        version cmakeVersionOverride
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #263

On Windows, the Android build fails when CMake object-file paths exceed `MAX_PATH` (260 chars). The NDK default CMake (3.22.1) can't handle the deeply-nested paths from Nitrogen's generated sources.

This is a [known issue across React Native libraries that use CMake](https://docs.swmansion.com/react-native-reanimated/docs/guides/building-on-windows/). Adds support for the `CMAKE_VERSION` env var (same as Reanimated) so users can opt into a newer CMake (e.g. 3.31.6) that handles long paths.