### PR TITLE
fix: prevent crash when trigger is called after dispose

### DIFF
--- a/src/hooks/__tests__/useDisposableMemo.test.ts
+++ b/src/hooks/__tests__/useDisposableMemo.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-native';
+import { type RefObject } from 'react';
 import { useDisposableMemo } from '../useDisposableMemo';
 
 function createDisposable(label: string) {
@@ -238,5 +239,96 @@ describe('useDisposableMemo', () => {
 
     rerender({ dep: -0 });
     expect(factory).toHaveBeenCalledTimes(3);
+  });
+
+  describe('liveRef tracking', () => {
+    it('sets liveRef.current on create', () => {
+      const liveRef: RefObject<Disposable | undefined> = { current: undefined };
+
+      renderHook(() =>
+        useDisposableMemo(
+          () => createDisposable('A'),
+          (d) => d.dispose(),
+          ['dep'],
+          liveRef
+        )
+      );
+
+      expect(liveRef.current).toBeDefined();
+      expect(liveRef.current!.label).toBe('A');
+      expect(liveRef.current!.isAlive).toBe(true);
+    });
+
+    it('clears liveRef on deps change and sets it to the new value', () => {
+      const liveRef: RefObject<Disposable | undefined> = { current: undefined };
+
+      const { rerender } = renderHook(
+        (props: { dep: string }) =>
+          useDisposableMemo(
+            () => createDisposable(props.dep),
+            (d) => d.dispose(),
+            [props.dep],
+            liveRef
+          ),
+        { initialProps: { dep: 'A' } }
+      );
+
+      const first = liveRef.current;
+      expect(first!.label).toBe('A');
+
+      rerender({ dep: 'B' });
+
+      expect(first!.isAlive).toBe(false);
+      expect(liveRef.current!.label).toBe('B');
+      expect(liveRef.current!.isAlive).toBe(true);
+    });
+
+    it('clears liveRef on unmount (deferred in dev)', () => {
+      const liveRef: RefObject<Disposable | undefined> = { current: undefined };
+
+      const { unmount } = renderHook(() =>
+        useDisposableMemo(
+          () => createDisposable('A'),
+          (d) => d.dispose(),
+          ['dep'],
+          liveRef
+        )
+      );
+
+      expect(liveRef.current).toBeDefined();
+
+      unmount();
+
+      // Deferred in dev — still set before timer fires
+      expect(liveRef.current).toBeDefined();
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(liveRef.current).toBeUndefined();
+    });
+
+    it('works without liveRef (existing behavior unchanged)', () => {
+      const { result, rerender, unmount } = renderHook(
+        (props: { dep: string }) =>
+          useDisposableMemo(
+            () => createDisposable(props.dep),
+            (d) => d.dispose(),
+            [props.dep]
+          ),
+        { initialProps: { dep: 'A' } }
+      );
+
+      expect(result.current.label).toBe('A');
+
+      rerender({ dep: 'B' });
+      expect(result.current.label).toBe('B');
+
+      unmount();
+      act(() => {
+        jest.runAllTimers();
+      });
+    });
   });
 });

--- a/src/hooks/__tests__/useRiveTrigger.test.ts
+++ b/src/hooks/__tests__/useRiveTrigger.test.ts
@@ -1,0 +1,130 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useRiveTrigger } from '../useRiveTrigger';
+import type { ViewModelInstance } from '../../specs/ViewModel.nitro';
+
+function createMockTriggerProperty() {
+  let listener: (() => void) | null = null;
+  return {
+    trigger: jest.fn(),
+    addListener: jest.fn((callback: () => void) => {
+      listener = callback;
+      return () => {
+        listener = null;
+      };
+    }),
+    dispose: jest.fn(),
+    fireListener() {
+      listener?.();
+    },
+  };
+}
+
+function createMockViewModelInstance(
+  propertyMap: Record<string, ReturnType<typeof createMockTriggerProperty>>
+) {
+  return {
+    triggerProperty: jest.fn((path: string) => propertyMap[path]),
+  } as unknown as ViewModelInstance;
+}
+
+describe('useRiveTrigger', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    try {
+      jest.runAllTimers();
+    } catch {
+      // Some tests intentionally dispose
+    }
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('calls trigger on the native property', () => {
+    const mockProperty = createMockTriggerProperty();
+    const mockInstance = createMockViewModelInstance({
+      'Button/Pressed': mockProperty,
+    });
+
+    const { result } = renderHook(() =>
+      useRiveTrigger('Button/Pressed', mockInstance)
+    );
+
+    act(() => {
+      result.current.trigger();
+    });
+
+    expect(mockProperty.trigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns when trigger is called before property is available', () => {
+    const { result } = renderHook(() =>
+      useRiveTrigger('Button/Pressed', undefined)
+    );
+
+    act(() => {
+      result.current.trigger();
+    });
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('not available yet')
+    );
+  });
+
+  it('warns when trigger is called after unmount', () => {
+    const mockProperty = createMockTriggerProperty();
+    const mockInstance = createMockViewModelInstance({
+      'Button/Pressed': mockProperty,
+    });
+
+    const { result, unmount } = renderHook(() =>
+      useRiveTrigger('Button/Pressed', mockInstance)
+    );
+
+    const { trigger } = result.current;
+
+    unmount();
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    trigger();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('called after dispose')
+    );
+    expect(mockProperty.trigger).not.toHaveBeenCalled();
+  });
+
+  it('invokes onTrigger callback when native trigger fires', () => {
+    const mockProperty = createMockTriggerProperty();
+    const mockInstance = createMockViewModelInstance({
+      'Button/Pressed': mockProperty,
+    });
+    const onTrigger = jest.fn();
+
+    renderHook(() =>
+      useRiveTrigger('Button/Pressed', mockInstance, { onTrigger })
+    );
+
+    act(() => {
+      mockProperty.fireListener();
+    });
+
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns error when property path is invalid', () => {
+    const mockInstance = createMockViewModelInstance({});
+
+    const { result } = renderHook(() =>
+      useRiveTrigger('nonexistent/path', mockInstance)
+    );
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toContain('nonexistent/path');
+  });
+});

--- a/src/hooks/useDisposableMemo.ts
+++ b/src/hooks/useDisposableMemo.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect, type DependencyList } from 'react';
+import { useRef, useEffect, type DependencyList, type RefObject } from 'react';
 
 const UNINITIALIZED = Symbol('UNINITIALIZED');
 
@@ -47,7 +47,8 @@ function depsEqual(a: DependencyList, b: DependencyList): boolean {
 export function useDisposableMemo<T>(
   factory: () => T,
   cleanup: (value: T) => void,
-  deps: DependencyList
+  deps: DependencyList,
+  liveRef?: RefObject<T | undefined>
 ): T {
   const ref = useRef<{
     value: T;
@@ -60,6 +61,8 @@ export function useDisposableMemo<T>(
   });
   const cleanupRef = useRef(cleanup);
   cleanupRef.current = cleanup;
+  const liveRefRef = useRef(liveRef);
+  liveRefRef.current = liveRef;
 
   if (
     ref.current.deps === UNINITIALIZED ||
@@ -70,6 +73,7 @@ export function useDisposableMemo<T>(
       ref.current.pendingDisposal = null;
     }
     if (ref.current.deps !== UNINITIALIZED) {
+      if (liveRefRef.current) liveRefRef.current.current = undefined;
       try {
         cleanupRef.current(ref.current.value);
       } catch {
@@ -77,6 +81,7 @@ export function useDisposableMemo<T>(
       }
     }
     ref.current = { value: factory(), deps, pendingDisposal: null };
+    if (liveRefRef.current) liveRefRef.current.current = ref.current.value;
   }
 
   useEffect(() => {
@@ -90,6 +95,7 @@ export function useDisposableMemo<T>(
       if (__DEV__) {
         const val = ref.current.value;
         ref.current.pendingDisposal = setTimeout(() => {
+          if (liveRefRef.current) liveRefRef.current.current = undefined;
           try {
             cleanupRef.current(val);
           } catch {
@@ -98,6 +104,7 @@ export function useDisposableMemo<T>(
           ref.current.pendingDisposal = null;
         }, 0);
       } else {
+        if (liveRefRef.current) liveRefRef.current.current = undefined;
         try {
           cleanupRef.current(ref.current.value);
         } catch {

--- a/src/hooks/useRiveTrigger.ts
+++ b/src/hooks/useRiveTrigger.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type ViewModelInstance } from '../specs/ViewModel.nitro';
+import {
+  type ViewModelInstance,
+  type ViewModelTriggerProperty,
+} from '../specs/ViewModel.nitro';
 import type {
   UseRiveTriggerResult,
   UseViewModelInstanceTriggerParameters,
@@ -24,6 +27,7 @@ export function useRiveTrigger(
   params?: UseViewModelInstanceTriggerParameters
 ): UseRiveTriggerResult {
   const { onTrigger } = params ?? {};
+  const liveRef = useRef<ViewModelTriggerProperty | undefined>(undefined);
 
   const onTriggerRef = useRef(onTrigger);
   onTriggerRef.current = onTrigger;
@@ -34,7 +38,8 @@ export function useRiveTrigger(
       return viewModelInstance.triggerProperty(path);
     },
     (p) => p?.dispose(),
-    [viewModelInstance, path]
+    [viewModelInstance, path],
+    liveRef
   );
 
   const [error, setError] = useState<Error | null>(null);
@@ -68,10 +73,16 @@ export function useRiveTrigger(
   }, [property]);
 
   const trigger = useCallback(() => {
-    if (property) {
-      property.trigger();
+    if (!liveRef.current) {
+      console.warn(
+        `useRiveTrigger: trigger('${path}') called after dispose. ` +
+          'The property has been cleaned up — this is likely a stale closure ' +
+          'from an async callback that fired after unmount.'
+      );
+      return;
     }
-  }, [property]);
+    liveRef.current.trigger();
+  }, [path]);
 
   return { trigger, error };
 }

--- a/src/hooks/useRiveTrigger.ts
+++ b/src/hooks/useRiveTrigger.ts
@@ -28,6 +28,7 @@ export function useRiveTrigger(
 ): UseRiveTriggerResult {
   const { onTrigger } = params ?? {};
   const liveRef = useRef<ViewModelTriggerProperty | undefined>(undefined);
+  const wasEverLive = useRef(false);
 
   const onTriggerRef = useRef(onTrigger);
   onTriggerRef.current = onTrigger;
@@ -41,6 +42,10 @@ export function useRiveTrigger(
     [viewModelInstance, path],
     liveRef
   );
+
+  if (liveRef.current) {
+    wasEverLive.current = true;
+  }
 
   const [error, setError] = useState<Error | null>(null);
 
@@ -74,11 +79,18 @@ export function useRiveTrigger(
 
   const trigger = useCallback(() => {
     if (!liveRef.current) {
-      console.warn(
-        `useRiveTrigger: trigger('${path}') called after dispose. ` +
-          'The property has been cleaned up — this is likely a stale closure ' +
-          'from an async callback that fired after unmount.'
-      );
+      if (wasEverLive.current) {
+        console.warn(
+          `useRiveTrigger: trigger('${path}') called after dispose. ` +
+            'The property has been cleaned up — this is likely a stale closure ' +
+            'from an async callback that fired after unmount.'
+        );
+      } else {
+        console.warn(
+          `useRiveTrigger: trigger('${path}') called but the property is not available yet. ` +
+            'The viewModelInstance may still be loading.'
+        );
+      }
       return;
     }
     liveRef.current.trigger();


### PR DESCRIPTION
Calling `trigger()` from a stale closure (e.g. a Reanimated callback that fires after navigation/unmount) would crash because the native property was already disposed.

`useDisposableMemo` now accepts an optional `liveRef` parameter — set on create, cleared on dispose. `useRiveTrigger` uses this to safely no-op with a `console.warn` instead of crashing.

Reproducer: mount RiveView with trigger → unmount → call trigger from async callback.