### PR TITLE
Add fromBytes, RiveImages, log level, and view method tests

### DIFF
--- a/example/__tests__/rive.harness.ts
+++ b/example/__tests__/rive.harness.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'react-native-harness';
 import { Platform } from 'react-native';
-import { RiveFileFactory } from '@rive-app/react-native';
+import { RiveFileFactory, RiveImages, RiveLog } from '@rive-app/react-native';
 
 const QUICK_START = require('../assets/rive/quick_start.riv');
 const VIEWMODEL = require('../assets/rive/viewmodelproperty.riv');
@@ -17,6 +17,18 @@ describe('RiveFile Loading', () => {
       'https://cdn.rive.app/animations/vehicles.riv',
       undefined
     );
+    expect(file).toBeDefined();
+    expect(file.artboardNames.length).toBeGreaterThan(0);
+  });
+
+  it('fromBytes works', async () => {
+    // Load the file first via fromSource, then get the URL and fetch raw bytes
+    // Simpler: use fromURL to get a known .riv, then re-load via fromBytes
+    const response = await fetch(
+      'https://cdn.rive.app/animations/vehicles.riv'
+    );
+    const bytes = await response.arrayBuffer();
+    const file = await RiveFileFactory.fromBytes(bytes, undefined);
     expect(file).toBeDefined();
     expect(file.artboardNames.length).toBeGreaterThan(0);
   });
@@ -74,5 +86,24 @@ describe('ViewModel', () => {
     const vm1NameProp = vm1AfterReplace?.stringProperty('name');
     const val = vm1NameProp?.value;
     expect(val).toBe(testValue);
+  });
+});
+
+describe('RiveImages', () => {
+  it('loadFromURLAsync loads an image', async () => {
+    const image = await RiveImages.loadFromURLAsync(
+      'https://picsum.photos/id/237/100/100'
+    );
+    expect(image).toBeDefined();
+    expect(image.byteSize).toBeGreaterThan(0);
+  });
+});
+
+describe('RiveLog.setLogLevel', () => {
+  it('setLogLevel does not throw for valid levels', () => {
+    expect(() => RiveLog.setLogLevel('debug')).not.toThrow();
+    expect(() => RiveLog.setLogLevel('info')).not.toThrow();
+    expect(() => RiveLog.setLogLevel('warn')).not.toThrow();
+    expect(() => RiveLog.setLogLevel('error')).not.toThrow();
   });
 });

--- a/example/__tests__/view-methods.harness.tsx
+++ b/example/__tests__/view-methods.harness.tsx
@@ -1,0 +1,96 @@
+import {
+  describe,
+  it,
+  expect,
+  render,
+  waitFor,
+  cleanup,
+} from 'react-native-harness';
+import { useEffect } from 'react';
+import { View } from 'react-native';
+import {
+  RiveView,
+  RiveFileFactory,
+  Fit,
+  type RiveFile,
+  type RiveViewRef,
+} from '@rive-app/react-native';
+
+const BOUNCING_BALL = require('../assets/rive/bouncing_ball.riv');
+
+type TestContext = {
+  ref: RiveViewRef | null;
+  error: string | null;
+};
+
+function SimpleRiveView({
+  file,
+  context,
+}: {
+  file: RiveFile;
+  context: TestContext;
+}) {
+  useEffect(() => {
+    return () => {
+      context.ref = null;
+    };
+  }, [context]);
+
+  return (
+    <View style={{ width: 200, height: 200 }}>
+      <RiveView
+        hybridRef={{
+          f: (ref: RiveViewRef | null) => {
+            context.ref = ref;
+          },
+        }}
+        style={{ flex: 1 }}
+        file={file}
+        autoPlay={true}
+        fit={Fit.Contain}
+        onError={(e) => {
+          context.error = e.message;
+        }}
+      />
+    </View>
+  );
+}
+
+describe('RiveView methods', () => {
+  it('pause() does not throw', async () => {
+    const file = await RiveFileFactory.fromSource(BOUNCING_BALL, undefined);
+    const context: TestContext = { ref: null, error: null };
+
+    await render(<SimpleRiveView file={file} context={context} />);
+    await waitFor(() => expect(context.ref).not.toBeNull(), { timeout: 5000 });
+
+    await context.ref!.pause();
+    expect(context.error).toBeNull();
+    cleanup();
+  });
+
+  it('play() after pause() does not throw', async () => {
+    const file = await RiveFileFactory.fromSource(BOUNCING_BALL, undefined);
+    const context: TestContext = { ref: null, error: null };
+
+    await render(<SimpleRiveView file={file} context={context} />);
+    await waitFor(() => expect(context.ref).not.toBeNull(), { timeout: 5000 });
+
+    await context.ref!.pause();
+    await context.ref!.play();
+    expect(context.error).toBeNull();
+    cleanup();
+  });
+
+  it('reset() does not throw', async () => {
+    const file = await RiveFileFactory.fromSource(BOUNCING_BALL, undefined);
+    const context: TestContext = { ref: null, error: null };
+
+    await render(<SimpleRiveView file={file} context={context} />);
+    await waitFor(() => expect(context.ref).not.toBeNull(), { timeout: 5000 });
+
+    await context.ref!.reset();
+    expect(context.error).toBeNull();
+    cleanup();
+  });
+});


### PR DESCRIPTION
Adds 7 new tests covering previously untested native code paths:

- **fromBytes**: load .riv from raw ArrayBuffer (HybridRiveFileFactory)
- **RiveImages.loadFromURLAsync**: load image and verify byteSize (HybridRiveImageFactory + HybridRiveImage)
- **RiveLog.setLogLevel**: exercise all 4 log levels (HybridRiveLogger)
- **RiveView pause/play/reset**: exercise view control methods with a rendered RiveView (HybridRiveView)