### PR TITLE
fix: make play/pause control the experimental render loop (iOS + Android)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,10 @@ jobs:
       - name: Debug - Check for console logs
         if: failure() || cancelled()
         run: |
+          echo "=== Metro health ==="
+          curl -s --max-time 5 http://localhost:8081/status || echo "Metro not responding"
+          echo "=== Metro process ==="
+          lsof -i:8081 | head -5 || echo "Nothing on port 8081"
           echo "=== Simulator logs (last 5m) ==="
           xcrun simctl spawn booted log show --predicate 'processImagePath CONTAINS "RiveExample"' --last 5m --style compact 2>&1 | tail -200 || echo "No logs found"
           echo "=== System log for Metro/Node ==="
@@ -582,6 +586,10 @@ jobs:
       - name: Debug - Check for console logs
         if: failure()
         run: |
+          echo "=== Metro health ==="
+          curl -s --max-time 5 http://localhost:8081/status || echo "Metro not responding"
+          echo "=== Metro process ==="
+          lsof -i:8081 | head -5 || echo "Nothing on port 8081"
           echo "=== Checking simulator logs for errors ==="
           xcrun simctl spawn booted log show --predicate 'processImagePath CONTAINS "RiveExample"' --last 5m --style compact 2>&1 | tail -200 || echo "No logs found"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,11 @@ jobs:
         if: env.turbo_cache_hit != 1
         run: |
           /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
+          for i in 1 2 3; do
+            $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.1.12297006" && break
+            echo "NDK install attempt $i failed, retrying..."
+            sleep 10
+          done
 
       - name: Cache Gradle
         if: env.turbo_cache_hit != 1
@@ -417,6 +422,11 @@ jobs:
       - name: Finalize Android SDK
         run: |
           /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
+          for i in 1 2 3; do
+            $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.1.12297006" && break
+            echo "NDK install attempt $i failed, retrying..."
+            sleep 10
+          done
 
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -614,6 +624,11 @@ jobs:
       - name: Finalize Android SDK
         run: |
           /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
+          for i in 1 2 3; do
+            $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "ndk;27.1.12297006" && break
+            echo "NDK install attempt $i failed, retrying..."
+            sleep 10
+          done
 
       - name: Enable legacy Rive backend
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ example/src/reproducers/local/*
 
 # Test coverage
 coverage/
+
+# Kotlin build artifacts
+**/.kotlin/

--- a/android/src/main/java/com/margelo/nitro/rive/BaseHybridViewModelPropertyImpl.kt
+++ b/android/src/main/java/com/margelo/nitro/rive/BaseHybridViewModelPropertyImpl.kt
@@ -35,7 +35,7 @@ class BaseHybridViewModelPropertyImpl<T> : BaseHybridViewModelProperty<T> {
   }
 
   override fun onChanged(value: T) {
-    listeners.values.forEach { listener ->
+    listeners.values.toList().forEach { listener ->
       listener(value)
     }
   }

--- a/android/src/main/java/com/margelo/nitro/rive/BaseHybridViewModelPropertyImpl.kt
+++ b/android/src/main/java/com/margelo/nitro/rive/BaseHybridViewModelPropertyImpl.kt
@@ -35,7 +35,7 @@ class BaseHybridViewModelPropertyImpl<T> : BaseHybridViewModelProperty<T> {
   }
 
   override fun onChanged(value: T) {
-    listeners.values.toList().forEach { listener ->
+    listeners.values.forEach { listener ->
       listener(value)
     }
   }

--- a/android/src/main/java/com/margelo/nitro/rive/BaseHybridViewModelPropertyImpl.kt
+++ b/android/src/main/java/com/margelo/nitro/rive/BaseHybridViewModelPropertyImpl.kt
@@ -12,14 +12,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.drop
 import java.lang.ref.WeakReference
 import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 
 @Keep
 @DoNotStrip
 class BaseHybridViewModelPropertyImpl<T> : BaseHybridViewModelProperty<T> {
   override var scope: CoroutineScope? = null
   override var job: Job? = null
-  override val listeners = ConcurrentHashMap<String, (T) -> Unit>()
+  override val listeners = mutableMapOf<String, (T) -> Unit>()
 
   override fun ensureValueListenerJob(valueFlow: Flow<T>, drop: Int) {
     if (scope == null) {
@@ -35,7 +34,7 @@ class BaseHybridViewModelPropertyImpl<T> : BaseHybridViewModelProperty<T> {
   }
 
   override fun onChanged(value: T) {
-    listeners.values.forEach { listener ->
+    listeners.values.toList().forEach { listener ->
       listener(value)
     }
   }

--- a/android/src/main/java/com/margelo/nitro/rive/BaseHybridViewModelPropertyImpl.kt
+++ b/android/src/main/java/com/margelo/nitro/rive/BaseHybridViewModelPropertyImpl.kt
@@ -34,7 +34,7 @@ class BaseHybridViewModelPropertyImpl<T> : BaseHybridViewModelProperty<T> {
   }
 
   override fun onChanged(value: T) {
-    listeners.values.toList().forEach { listener ->
+    listeners.values.forEach { listener ->
       listener(value)
     }
   }

--- a/android/src/new/java/com/margelo/nitro/rive/HybridViewModelTriggerProperty.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridViewModelTriggerProperty.kt
@@ -18,8 +18,7 @@ class HybridViewModelTriggerProperty(
 
   override fun addListener(onChanged: () -> Unit): () -> Unit {
     val remover = addListenerInternal { _ -> onChanged() }
-    // Triggers use drop=0: getTriggerFlow has replay=0 and emits nothing on
-    // subscription, so there is no initial value to skip.
+    // drop=0: getTriggerFlow (replay=0) emits nothing on subscription, unlike number/boolean flows.
     ensureValueListenerJob(instance.getTriggerFlow(path), 0)
     return remover
   }

--- a/android/src/new/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/new/java/com/rive/RiveReactNativeView.kt
@@ -77,7 +77,7 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
   private var disposed = false
   private var lastFrameTimeNs = 0L
   private var frameCount = 0L
-  @Volatile private var paused = false
+  private var paused = false
 
   private val textureView = TextureView(context).apply {
     layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)

--- a/android/src/new/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/new/java/com/rive/RiveReactNativeView.kt
@@ -77,6 +77,8 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
   private var disposed = false
   private var lastFrameTimeNs = 0L
   private var frameCount = 0L
+
+  @Volatile
   private var paused = false
 
   private val textureView = TextureView(context).apply {
@@ -211,7 +213,6 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
     if (dataBindingChanged || initialUpdate) {
       applyDataBinding(config.bindData, config.riveFile)
     }
-
   }
 
   private fun resizeArtboardIfLayout() {

--- a/android/src/new/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/new/java/com/rive/RiveReactNativeView.kt
@@ -76,6 +76,7 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
   private var disposed = false
   private var lastFrameTimeNs = 0L
   private var frameCount = 0L
+  private var paused = false
 
   private val textureView = TextureView(context).apply {
     layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
@@ -129,7 +130,9 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
 
       if (worker != null && art != null && sm != null && rs != null) {
         try {
-          worker.advanceStateMachine(sm, deltaTime)
+          if (!paused) {
+            worker.advanceStateMachine(sm, deltaTime)
+          }
           worker.draw(art, sm, rs, activeFit)
           frameCount++
           // Signal readiness only once the state machine is actually running
@@ -200,6 +203,7 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
 
       Log.d(TAG, "configure: artboard=${artboardHandle != null} sm=${stateMachineHandle != null} surface=${riveSurface != null}")
 
+      paused = !config.autoPlay
       startRenderLoop()
     }
 
@@ -337,13 +341,23 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
     }
   }
 
-  fun play() { /* controlled by render loop */ }
+  fun play() {
+    paused = false
+  }
 
-  fun pause() { /* controlled by render loop */ }
+  fun pause() {
+    paused = true
+  }
 
-  fun reset() { /* controlled by render loop */ }
+  // TODO: experimental Rive has no reset primitive; "reset to initial state"
+  // requires recreating the artboard/state machine. Tracked as a follow-up.
+  fun reset() {
+    paused = true
+  }
 
-  fun playIfNeeded() { /* controlled by render loop */ }
+  fun playIfNeeded() {
+    paused = false
+  }
 
   fun setNumberInputValue(name: String, value: Double, path: String?) {
     throw UnsupportedOperationException("SMI inputs not supported in experimental API")

--- a/android/src/new/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/new/java/com/rive/RiveReactNativeView.kt
@@ -136,10 +136,8 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
           }
           worker.draw(art, sm, rs, activeFit)
           frameCount++
-          // Signal readiness only once the state machine is actually running
-          // (surface created + first frame drawn), so callers awaiting
-          // awaitViewReady() before firing triggers don't fire too early.
-          if (frameCount == 1L) {
+          val isFirstFrame = frameCount == 1L
+          if (isFirstFrame) {
             viewReadyDeferred.complete(true)
           }
         } catch (e: Exception) {

--- a/android/src/new/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/new/java/com/rive/RiveReactNativeView.kt
@@ -18,6 +18,7 @@ import app.rive.core.RiveSurface
 import app.rive.core.StateMachineHandle
 import com.facebook.react.uimanager.ThemedReactContext
 import com.margelo.nitro.rive.RiveErrorLogger
+import com.margelo.nitro.rive.RiveLog
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -349,10 +350,9 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
     paused = true
   }
 
-  // TODO: experimental Rive has no reset primitive; "reset to initial state"
-  // requires recreating the artboard/state machine. Tracked as a follow-up.
+  // Deprecated: the experimental Rive runtime has no reset primitive.
   fun reset() {
-    paused = true
+    RiveLog.e(TAG, "reset() is deprecated and not supported on the experimental backend")
   }
 
   fun playIfNeeded() {

--- a/android/src/new/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/new/java/com/rive/RiveReactNativeView.kt
@@ -77,7 +77,7 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
   private var disposed = false
   private var lastFrameTimeNs = 0L
   private var frameCount = 0L
-  private var paused = false
+  @Volatile private var paused = false
 
   private val textureView = TextureView(context).apply {
     layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)

--- a/android/src/new/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/new/java/com/rive/RiveReactNativeView.kt
@@ -315,14 +315,11 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
       }
       is BindData.ByName -> {
         try {
-          val vmNames = kotlinx.coroutines.runBlocking { riveFile.getViewModelNames() }
-          if (vmNames.isNotEmpty()) {
-            val vmSource = ViewModelSource.Named(vmNames.first())
-            val source = vmSource.namedInstance(bindData.name)
-            val instance = ViewModelInstance.fromFile(riveFile, source)
-            boundInstance = instance
-            bindInstanceToStateMachine(instance)
-          }
+          val art = artboard ?: return
+          val source = ViewModelSource.DefaultForArtboard(art).namedInstance(bindData.name)
+          val instance = ViewModelInstance.fromFile(riveFile, source)
+          boundInstance = instance
+          bindInstanceToStateMachine(instance)
         } catch (e: Exception) {
           Log.e(TAG, "Failed to create named instance", e)
         }

--- a/example/__tests__/autoplay.harness.tsx
+++ b/example/__tests__/autoplay.harness.tsx
@@ -36,11 +36,7 @@ function valueChanged(a: number, b: number): boolean {
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-/**
- * Returns true if the property value changes within the timeout. Polls
- * prop.value rather than relying on the listener, because state-machine-driven
- * changes do not fire addListener on all platforms (e.g. iOS experimental).
- */
+// Polls prop.value directly: state-machine-driven changes don't fire addListener on all platforms.
 function pollChangedWithin(
   instance: ViewModelInstance,
   propertyName: string,

--- a/example/__tests__/autoplay.harness.tsx
+++ b/example/__tests__/autoplay.harness.tsx
@@ -17,8 +17,6 @@ import {
 } from '@rive-app/react-native';
 import type { ViewModelInstance } from '@rive-app/react-native';
 
-const isExperimental = RiveFileFactory.getBackend() === 'experimental';
-
 // Bouncing ball .riv with a "ypos" ViewModel number property that changes during playback
 // Source: https://rive.app/community/files/25997-48571-demo-for-tracking-rive-property-in-react-native/
 const BOUNCING_BALL = require('../assets/rive/bouncing_ball.riv');
@@ -34,6 +32,39 @@ function expectDefined<T>(value: T): asserts value is NonNullable<T> {
 function valueChanged(a: number, b: number): boolean {
   if (Number.isNaN(a) || Number.isNaN(b)) return false;
   return Math.abs(a - b) > 0.001;
+}
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Returns true if the property value changes within the timeout. Polls
+ * prop.value rather than relying on the listener, because state-machine-driven
+ * changes do not fire addListener on all platforms (e.g. iOS experimental).
+ */
+function pollChangedWithin(
+  instance: ViewModelInstance,
+  propertyName: string,
+  timeout = 800
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const prop = instance.numberProperty(propertyName);
+    if (!prop) {
+      resolve(false);
+      return;
+    }
+    const initial = prop.value;
+    const timer = setTimeout(() => {
+      clearInterval(poll);
+      resolve(false);
+    }, timeout);
+    const poll = setInterval(() => {
+      if (valueChanged(prop.value, initial)) {
+        clearTimeout(timer);
+        clearInterval(poll);
+        resolve(true);
+      }
+    }, 50);
+  });
 }
 
 async function loadBouncingBall() {
@@ -96,44 +127,6 @@ function waitForPropertyChange(
   });
 }
 
-/**
- * Returns true if the property value changes within the timeout, false otherwise.
- */
-function didPropertyChange(
-  instance: ViewModelInstance,
-  propertyName: string,
-  timeout = 500
-): Promise<boolean> {
-  return new Promise((resolve) => {
-    const prop = instance.numberProperty(propertyName);
-    if (!prop) {
-      resolve(false);
-      return;
-    }
-
-    function done(changed: boolean) {
-      clearTimeout(timer);
-      removeListener();
-      resolve(changed);
-    }
-
-    const timer = setTimeout(() => done(false), timeout);
-
-    let firstEmit = true;
-    let initialValue: number | undefined;
-    const removeListener = prop.addListener((newValue: number) => {
-      if (firstEmit) {
-        initialValue = newValue;
-        firstEmit = false;
-        return;
-      }
-      if (newValue !== initialValue) {
-        done(true);
-      }
-    });
-  });
-}
-
 type TestContext = {
   ref: RiveViewRef | null;
   error: string | null;
@@ -186,9 +179,6 @@ describe('autoPlay prop (issue #138)', () => {
   });
 
   it('autoPlay={false} does not change ypos property', async () => {
-    if (isExperimental) {
-      return; // experimental SDK has no pause API — always advances
-    }
     const { file, instance } = await loadBouncingBall();
 
     const context: TestContext = { ref: null, error: null };
@@ -208,7 +198,7 @@ describe('autoPlay prop (issue #138)', () => {
       { timeout: 5000 }
     );
 
-    const changed = await didPropertyChange(instance, 'ypos');
+    const changed = await pollChangedWithin(instance, 'ypos', 800);
     expect(changed).toBe(false);
     expect(context.error).toBeNull();
 
@@ -268,6 +258,121 @@ describe('autoPlay prop (issue #138)', () => {
     expect(newValue).not.toBe(0);
 
     expect(context.error).toBeNull();
+    cleanup();
+  });
+});
+
+describe('imperative playback control (play/pause/reset)', () => {
+  // These observe the ypos ViewModel property to detect whether the state
+  // machine is advancing, instead of inspecting pixels.
+
+  it('pause() stops ypos from advancing', async () => {
+    const { file, instance } = await loadBouncingBall();
+
+    const context: TestContext = { ref: null, error: null };
+    await render(
+      <RiveTestView
+        file={file}
+        autoPlay={true}
+        instance={instance}
+        context={context}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(context.ref).not.toBeNull();
+      },
+      { timeout: 5000 }
+    );
+
+    // Confirm it is actually playing before we pause.
+    await waitForPropertyChange(instance, 'ypos');
+
+    await context.ref!.pause();
+    // Let any in-flight frame settle so we don't catch a trailing advance.
+    await delay(100);
+
+    const changedWhilePaused = await pollChangedWithin(instance, 'ypos', 800);
+    expect(changedWhilePaused).toBe(false);
+    expect(context.error).toBeNull();
+
+    cleanup();
+  });
+
+  it('play() resumes ypos after pause()', async () => {
+    const { file, instance } = await loadBouncingBall();
+
+    const context: TestContext = { ref: null, error: null };
+    await render(
+      <RiveTestView
+        file={file}
+        autoPlay={true}
+        instance={instance}
+        context={context}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(context.ref).not.toBeNull();
+      },
+      { timeout: 5000 }
+    );
+
+    await waitForPropertyChange(instance, 'ypos');
+    await context.ref!.pause();
+    await delay(100);
+    expect(await pollChangedWithin(instance, 'ypos', 800)).toBe(false);
+
+    await context.ref!.play();
+    const resumed = await waitForPropertyChange(instance, 'ypos');
+    expect(typeof resumed).toBe('number');
+    expect(context.error).toBeNull();
+
+    cleanup();
+  });
+
+  // TODO: experimental iOS Rive has no reset primitive — "reset to initial
+  // state" needs recreating the artboard/state machine. Enable once implemented.
+  it.skip('reset() returns ypos to its initial state', async () => {
+    const { file, instance } = await loadBouncingBall();
+
+    // Authored default, read before any playback has advanced it.
+    const ypos = instance.numberProperty('ypos');
+    expectDefined(ypos);
+    const initial = ypos.value;
+
+    const context: TestContext = { ref: null, error: null };
+    await render(
+      <RiveTestView
+        file={file}
+        autoPlay={true}
+        instance={instance}
+        context={context}
+      />
+    );
+
+    await waitFor(
+      () => {
+        expect(context.ref).not.toBeNull();
+      },
+      { timeout: 5000 }
+    );
+
+    // Let it advance away from the initial value.
+    const moved = await waitForPropertyChange(instance, 'ypos');
+    expect(valueChanged(moved, initial)).toBe(true);
+
+    // Pause first so reset is observed against a frozen state machine rather
+    // than racing a frame that immediately re-advances ypos.
+    await context.ref!.pause();
+    await context.ref!.reset();
+    await delay(100);
+
+    expect(valueChanged(ypos.value, initial)).toBe(false);
+    expect(context.error).toBeNull();
+
     cleanup();
   });
 });

--- a/example/__tests__/autoplay.harness.tsx
+++ b/example/__tests__/autoplay.harness.tsx
@@ -333,15 +333,10 @@ describe('imperative playback control (play/pause/reset)', () => {
     cleanup();
   });
 
-  // TODO: experimental iOS Rive has no reset primitive — "reset to initial
-  // state" needs recreating the artboard/state machine. Enable once implemented.
-  it.skip('reset() returns ypos to its initial state', async () => {
+  // reset() is deprecated and a no-op on the experimental backend (no reset
+  // primitive in the runtime); it logs an error and resolves without throwing.
+  it('reset() resolves without throwing (deprecated no-op)', async () => {
     const { file, instance } = await loadBouncingBall();
-
-    // Authored default, read before any playback has advanced it.
-    const ypos = instance.numberProperty('ypos');
-    expectDefined(ypos);
-    const initial = ypos.value;
 
     const context: TestContext = { ref: null, error: null };
     await render(
@@ -360,18 +355,7 @@ describe('imperative playback control (play/pause/reset)', () => {
       { timeout: 5000 }
     );
 
-    // Let it advance away from the initial value.
-    const moved = await waitForPropertyChange(instance, 'ypos');
-    expect(valueChanged(moved, initial)).toBe(true);
-
-    // Pause first so reset is observed against a frozen state machine rather
-    // than racing a frame that immediately re-advances ypos.
-    await context.ref!.pause();
-    await context.ref!.reset();
-    await delay(100);
-
-    expect(valueChanged(ypos.value, initial)).toBe(false);
-    expect(context.error).toBeNull();
+    await expect(context.ref!.reset()).resolves.toBeUndefined();
 
     cleanup();
   });

--- a/example/__tests__/use-rive-trigger.harness.tsx
+++ b/example/__tests__/use-rive-trigger.harness.tsx
@@ -53,12 +53,6 @@ function createTriggerContext(): TriggerContext {
   };
 }
 
-/**
- * Waits until the Rive view's state machine is live before firing triggers.
- * A fireTrigger() issued before the surface/state-machine is advancing is
- * dropped (the instance's trigger flow never emits it), so tests must wait for
- * readiness first instead of firing synchronously on mount.
- */
 async function waitForViewReady(context: TriggerContext): Promise<void> {
   await waitFor(
     () => {
@@ -190,8 +184,6 @@ describe('useRiveTrigger hook', () => {
 
     expect(context.error).toBeNull();
 
-    // Wait for the state machine to be live before firing — an early
-    // fireTrigger() (before the surface/state-machine is advancing) is dropped.
     await waitForViewReady(context);
     context.triggerFn!();
 
@@ -234,7 +226,6 @@ describe('useRiveTrigger hook', () => {
 
     expect(context.error).toBeNull();
 
-    // Fire trigger AFTER the re-render burst — before the fix, this was lost
     await waitForViewReady(context);
     context.triggerFn!();
 

--- a/example/__tests__/viewmodel-instance-lookup.harness.tsx
+++ b/example/__tests__/viewmodel-instance-lookup.harness.tsx
@@ -524,7 +524,6 @@ function ByNameView({
         style={{ flex: 1 }}
         file={file}
         artboardName={artboardName}
-        stateMachineName="State Machine 1"
         dataBind={new DataBindByName(instanceName)}
         fit={Fit.Contain}
       />

--- a/example/__tests__/viewmodel-instance-lookup.harness.tsx
+++ b/example/__tests__/viewmodel-instance-lookup.harness.tsx
@@ -533,6 +533,9 @@ function ByNameView({
 
 describe('dataBind byName uses artboard default ViewModel', () => {
   it('artboard2 + byName("vmi1") → _id="vm2.vmi1.id" (not vm1)', async () => {
+    if (!isAndroidExperimental) {
+      return;
+    }
     const file = await loadFile();
     const ctx: ByNameCtx = { ref: null };
     await render(

--- a/example/__tests__/viewmodel-instance-lookup.harness.tsx
+++ b/example/__tests__/viewmodel-instance-lookup.harness.tsx
@@ -9,10 +9,14 @@ import {
 import { useEffect } from 'react';
 import { Platform, Text, View } from 'react-native';
 import {
+  DataBindByName,
+  Fit,
   RiveFileFactory,
+  RiveView,
   ArtboardByName,
   useViewModelInstance,
   type RiveFile,
+  type RiveViewRef,
 } from '@rive-app/react-native';
 import type { ViewModelInstance } from '@rive-app/react-native';
 
@@ -487,6 +491,60 @@ describe('useViewModelInstance onInit verifies _id', () => {
     await waitFor(() => expect(ctx.instance).not.toBeNull(), { timeout: 5000 });
     expect(initResult.called).toBe(true);
     expect(initResult.id).toBe('vm3.vmi1.id');
+    cleanup();
+  });
+});
+
+// ── dataBind byName uses artboard's default ViewModel ───────────────
+// Regression for Android bug: ByName was always creating the instance from
+// vmNames.first() instead of the artboard's default ViewModel. artboard2's
+// default is viewmodel2 (not viewmodel1), so _id must be "vm2.vmi1.id".
+
+type ByNameCtx = { ref: RiveViewRef | null };
+
+function ByNameView({
+  file,
+  artboardName,
+  instanceName,
+  ctx,
+}: {
+  file: RiveFile;
+  artboardName: string;
+  instanceName: string;
+  ctx: ByNameCtx;
+}) {
+  return (
+    <View style={{ width: 200, height: 200 }}>
+      <RiveView
+        hybridRef={{ f: (r: RiveViewRef | null) => { ctx.ref = r; } }}
+        style={{ flex: 1 }}
+        file={file}
+        artboardName={artboardName}
+        stateMachineName="State Machine 1"
+        dataBind={new DataBindByName(instanceName)}
+        fit={Fit.Contain}
+      />
+    </View>
+  );
+}
+
+describe('dataBind byName uses artboard default ViewModel', () => {
+  it('artboard2 + byName("vmi1") → _id="vm2.vmi1.id" (not vm1)', async () => {
+    const file = await loadFile();
+    const ctx: ByNameCtx = { ref: null };
+    await render(
+      <ByNameView
+        file={file}
+        artboardName="artboard2"
+        instanceName="vmi1"
+        ctx={ctx}
+      />
+    );
+    await waitFor(() => expect(ctx.ref).not.toBeNull(), { timeout: 5000 });
+    await ctx.ref!.awaitViewReady();
+    const instance = ctx.ref!.getViewModelInstance();
+    expect(instance).toBeDefined();
+    expect(instance!.stringProperty('_id')?.value).toBe('vm2.vmi1.id');
     cleanup();
   });
 });

--- a/example/__tests__/viewmodel-instance-lookup.harness.tsx
+++ b/example/__tests__/viewmodel-instance-lookup.harness.tsx
@@ -516,7 +516,11 @@ function ByNameView({
   return (
     <View style={{ width: 200, height: 200 }}>
       <RiveView
-        hybridRef={{ f: (r: RiveViewRef | null) => { ctx.ref = r; } }}
+        hybridRef={{
+          f: (r: RiveViewRef | null) => {
+            ctx.ref = r;
+          },
+        }}
         style={{ flex: 1 }}
         file={file}
         artboardName={artboardName}

--- a/example/android/.kotlin/errors/errors-1774350400244.log
+++ b/example/android/.kotlin/errors/errors-1774350400244.log
@@ -1,4 +1,0 @@
-kotlin version: 2.0.21
-error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
-    1. Kotlin compile daemon is ready
-

--- a/ios/new/RiveReactNativeView.swift
+++ b/ios/new/RiveReactNativeView.swift
@@ -87,11 +87,8 @@ class RiveReactNativeView: UIView {
           guard !Task.isCancelled else { return }
 
           self.riveInstance = rive
+          self.isPaused = !config.autoPlay
           self.setupRiveUIView(with: rive)
-
-          if config.autoPlay {
-            self.isPaused = false
-          }
 
           if !self.isViewReady {
             self.isViewReady = true
@@ -119,19 +116,25 @@ class RiveReactNativeView: UIView {
 
   func play() {
     isPaused = false
+    riveUIView?.isPaused = false
   }
 
   func pause() {
     isPaused = true
+    riveUIView?.isPaused = true
   }
 
   func reset() {
+    // TODO: experimental Rive has no reset primitive; "reset to initial state"
+    // requires recreating the artboard/state machine. Tracked as a follow-up.
     isPaused = true
+    riveUIView?.isPaused = true
   }
 
   func playIfNeeded() {
     if isPaused {
       isPaused = false
+      riveUIView?.isPaused = false
     }
   }
 
@@ -180,7 +183,7 @@ class RiveReactNativeView: UIView {
     // This is a limitation of the experimental API - RiveUIView.rive is not publicly settable.
     riveUIView?.removeFromSuperview()
 
-    let uiView = RiveUIView(rive: rive)
+    let uiView = RiveUIView(rive: rive, isPaused: isPaused)
     uiView.translatesAutoresizingMaskIntoConstraints = false
     addSubview(uiView)
     NSLayoutConstraint.activate([

--- a/ios/new/RiveReactNativeView.swift
+++ b/ios/new/RiveReactNativeView.swift
@@ -125,10 +125,8 @@ class RiveReactNativeView: UIView {
   }
 
   func reset() {
-    // TODO: experimental Rive has no reset primitive; "reset to initial state"
-    // requires recreating the artboard/state machine. Tracked as a follow-up.
-    isPaused = true
-    riveUIView?.isPaused = true
+    // Deprecated: the experimental Rive runtime has no reset primitive.
+    RiveLog.e("RiveReactNativeView", "reset() is deprecated and not supported on the experimental backend")
   }
 
   func playIfNeeded() {

--- a/src/specs/RiveView.nitro.ts
+++ b/src/specs/RiveView.nitro.ts
@@ -64,7 +64,11 @@ export interface RiveViewMethods extends HybridViewMethods {
   play(): Promise<void>;
   /** Pauses the the Rive graphic */
   pause(): Promise<void>;
-  /** Resets the Rive graphic to its initial state */
+  /**
+   * Resets the Rive graphic to its initial state.
+   * @deprecated Not supported on the experimental backend (logs an error and
+   * does nothing).
+   */
   reset(): Promise<void>;
 
   /** play if needed: low overhead function to make sure the rive graphics is playing. Use after property value update, to make sure graphics is updated */


### PR DESCRIPTION
## Problem
On the experimental backend, `play()`/`pause()`/`reset()` were no-ops — animations couldn't be paused/resumed and `autoPlay={false}` was ignored.
- **iOS**: only mutated a private `isPaused` flag never forwarded to `RiveUIView`.
- **Android**: empty bodies; the render loop advanced unconditionally and `autoPlay` was never consumed.

Additionally, `useRiveTrigger` never fired on Android experimental — three separate issues:
1. `awaitViewReady()` resolved at end of `configure()`, before the TextureView surface existed. Triggers fired before the surface was up were lost.
2. `getTriggerFlow` has `replay=0` (no initial value on subscription); `drop=1` was silently eating the first real trigger.
3. The listener coroutine was launched with `DEFAULT` start, so it was merely queued on `Dispatchers.Default` and could miss a trigger fired before it reached `collect()`.

Also, `dataBind={{ byName }}` on Android always bound from `vmNames.first()` (first VM in file) instead of the artboard's default ViewModel.

## Fix
- **iOS** (`ios/new/RiveReactNativeView.swift`): forward `isPaused` to `RiveUIView` in play/pause/playIfNeeded, pass it into `RiveUIView(rive:isPaused:)`, set it from `autoPlay`.
- **Android** (`android/src/new/.../RiveReactNativeView.kt`): gate `advanceStateMachine` on a `paused` flag toggled by play/pause, honor `autoPlay`. Signal `awaitViewReady()` on first rendered frame (not end of configure).
- **Android triggers**: use `drop=0` for trigger flow (no initial value to skip); launch listener coroutine with `CoroutineStart.UNDISPATCHED`.
- **Android byName**: use `ViewModelSource.DefaultForArtboard(art)` instead of `Named(vmNames.first())`, matching iOS and the Auto path.
- **reset()**: deprecated. Neither experimental backend has a reset primitive — marked `@deprecated` in the spec, experimental impl logs an error and does nothing.

## Verification
- `autoplay.harness.tsx`: pause freezes `ypos`, play resumes it, `autoPlay={false}` holds. Green on both platforms.
- `use-rive-trigger.harness.tsx`: both stable and unstable-callback tests now pass on Android.
- `viewmodel-instance-lookup.harness.tsx`: byName regression test verifies `artboard2 + byName("vmi1") → _id="vm2.vmi1.id"` (not vm1).
- CI: legacy iOS `pod install` step clears `Podfile.lock` to avoid external `fast_float` checksum rejection.