### PR TITLE
fix(android): play/pause/reset don't need UI thread dispatch

### DIFF
--- a/android/src/new/java/com/margelo/nitro/rive/HybridRiveView.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridRiveView.kt
@@ -194,18 +194,6 @@ class HybridRiveView(val context: ThemedReactContext) : HybridRiveViewSpec() {
     }
   }
 
-  private fun asyncExecuteOnUiThread(action: () -> Unit): Promise<Unit> {
-    return Promise.async {
-      context.currentActivity?.runOnUiThread {
-        try {
-          action()
-        } catch (e: Exception) {
-          throw RuntimeException(e.message, e)
-        }
-      }
-    }
-  }
-
   private fun executeOnUiThread(action: () -> Unit) {
     context.currentActivity?.runOnUiThread {
       try {

--- a/android/src/new/java/com/margelo/nitro/rive/HybridRiveView.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridRiveView.kt
@@ -111,9 +111,9 @@ class HybridRiveView(val context: ThemedReactContext) : HybridRiveViewSpec() {
     return HybridViewModelInstance(vmi, hybridFile.riveWorker, hybridFile)
   }
 
-  override fun play() = asyncExecuteOnUiThread { view.play() }
-  override fun pause() = asyncExecuteOnUiThread { view.pause() }
-  override fun reset() = asyncExecuteOnUiThread { view.reset() }
+  override fun play(): Promise<Unit> = Promise.async { view.play() }
+  override fun pause(): Promise<Unit> = Promise.async { view.pause() }
+  override fun reset(): Promise<Unit> = Promise.async { view.reset() }
   override fun playIfNeeded() = view.playIfNeeded()
 
   override fun onEventListener(onEvent: (event: UnifiedRiveEvent) -> Unit) {


### PR DESCRIPTION
`asyncExecuteOnUiThread` posts to the UI thread and returns immediately, so the Promise resolves before the work runs. If the action throws, it crashes on the UI thread instead of rejecting the Promise.

`play()`/`pause()`/`reset()` on the experimental backend are just flag toggles or a deprecation log — no UI thread requirement, no throw. Replace with `Promise.async { view.play() }` etc.