### PR TITLE
fix(android): remove runBlocking from property accessors

### DIFF
--- a/android/src/new/java/com/margelo/nitro/rive/HybridViewModelInstance.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridViewModelInstance.kt
@@ -7,8 +7,6 @@ import app.rive.ViewModelInstanceSource
 import app.rive.core.CommandQueue
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.core.Promise
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 
 @Keep
 @DoNotStrip
@@ -21,22 +19,6 @@ class HybridViewModelInstance(
 ) : HybridViewModelInstanceSpec() {
   companion object {
     private const val TAG = "HybridViewModelInstance"
-  }
-
-  private val propertyNames: Set<String> by lazy {
-    val name = viewModelName ?: return@lazy emptySet()
-    val file = parentFile.riveFile ?: return@lazy emptySet()
-    try {
-      runBlocking { file.getViewModelProperties(name) }.map { it.name }.toSet()
-    } catch (e: Exception) {
-      Log.e(TAG, "Failed to fetch property names for viewModel '$name'", e)
-      emptySet()
-    }
-  }
-
-  private fun hasProperty(path: String): Boolean {
-    if (propertyNames.isEmpty()) return true
-    return propertyNames.contains(path)
   }
 
   // TODO: Workaround — rive-android experimental SDK doesn't expose ViewModelInstance.name.
@@ -56,65 +38,23 @@ class HybridViewModelInstance(
     }
   }
 
-  override fun numberProperty(path: String): HybridViewModelNumberPropertySpec? {
-    return try {
-      runBlocking { viewModelInstance.getNumberFlow(path).first() }
-      HybridViewModelNumberProperty(viewModelInstance, path)
-    } catch (e: Exception) {
-      Log.e(TAG, "numberProperty failed for path '$path'", e)
-      null
-    }
-  }
+  override fun numberProperty(path: String) =
+    HybridViewModelNumberProperty(viewModelInstance, path)
 
-  override fun stringProperty(path: String): HybridViewModelStringPropertySpec? {
-    return try {
-      runBlocking { viewModelInstance.getStringFlow(path).first() }
-      HybridViewModelStringProperty(viewModelInstance, path)
-    } catch (e: Exception) {
-      Log.e(TAG, "stringProperty failed for path '$path'", e)
-      null
-    }
-  }
+  override fun stringProperty(path: String) =
+    HybridViewModelStringProperty(viewModelInstance, path)
 
-  override fun booleanProperty(path: String): HybridViewModelBooleanPropertySpec? {
-    return try {
-      runBlocking { viewModelInstance.getBooleanFlow(path).first() }
-      HybridViewModelBooleanProperty(viewModelInstance, path)
-    } catch (e: Exception) {
-      Log.e(TAG, "booleanProperty failed for path '$path'", e)
-      null
-    }
-  }
+  override fun booleanProperty(path: String) =
+    HybridViewModelBooleanProperty(viewModelInstance, path)
 
-  override fun colorProperty(path: String): HybridViewModelColorPropertySpec? {
-    return try {
-      runBlocking { viewModelInstance.getColorFlow(path).first() }
-      HybridViewModelColorProperty(viewModelInstance, path)
-    } catch (e: Exception) {
-      Log.e(TAG, "colorProperty failed for path '$path'", e)
-      null
-    }
-  }
+  override fun colorProperty(path: String) =
+    HybridViewModelColorProperty(viewModelInstance, path)
 
-  override fun enumProperty(path: String): HybridViewModelEnumPropertySpec? {
-    return try {
-      runBlocking { viewModelInstance.getEnumFlow(path).first() }
-      HybridViewModelEnumProperty(viewModelInstance, path)
-    } catch (e: Exception) {
-      Log.e(TAG, "enumProperty failed for path '$path'", e)
-      null
-    }
-  }
+  override fun enumProperty(path: String) =
+    HybridViewModelEnumProperty(viewModelInstance, path)
 
-  override fun triggerProperty(path: String): HybridViewModelTriggerPropertySpec? {
-    if (!hasProperty(path)) return null
-    return try {
-      HybridViewModelTriggerProperty(viewModelInstance, path)
-    } catch (e: Exception) {
-      Log.e(TAG, "triggerProperty failed for path '$path'", e)
-      null
-    }
-  }
+  override fun triggerProperty(path: String) =
+    HybridViewModelTriggerProperty(viewModelInstance, path)
 
   override fun imageProperty(path: String): HybridViewModelImagePropertySpec? {
     return try {
@@ -144,7 +84,6 @@ class HybridViewModelInstance(
   }
 
   private fun viewModelImpl(path: String): HybridViewModelInstanceSpec? {
-    if (!hasProperty(path)) return null
     val file = parentFile.riveFile ?: return null
     val source = ViewModelInstanceSource.Reference(viewModelInstance, path)
     val childVmi = ViewModelInstance.fromFile(file, source)

--- a/example/__tests__/viewmodel-properties.harness.ts
+++ b/example/__tests__/viewmodel-properties.harness.ts
@@ -149,11 +149,9 @@ describe('ViewModel Properties', () => {
   });
 
   it('non-existent properties return undefined', async () => {
-    if (
-      Platform.OS === 'ios' &&
-      RiveFileFactory.getBackend() === 'experimental'
-    ) {
-      // Experimental API can't sync-validate property paths, returns wrapper objects
+    if (isExperimental()) {
+      // Experimental backends return wrapper objects for any path — validity is
+      // checked lazily when a value is read (getValueAsync throws).
       return;
     }
 
@@ -166,6 +164,22 @@ describe('ViewModel Properties', () => {
     expect(instance.enumProperty('nonexistent')).toBeUndefined();
     expect(instance.triggerProperty('nonexistent')).toBeUndefined();
     expect(await instance.viewModelAsync('nonexistent')).toBeUndefined();
+  });
+
+  it('experimental: getValueAsync throws for non-existent property path', async () => {
+    if (!isExperimental()) {
+      return;
+    }
+
+    const instance = await createGordonInstance();
+
+    const num = instance.numberProperty('nonexistent');
+    expectDefined(num);
+    await expect(num.getValueAsync()).rejects.toBeDefined();
+
+    const str = instance.stringProperty('nonexistent');
+    expectDefined(str);
+    await expect(str.getValueAsync()).rejects.toBeDefined();
   });
 });
 

--- a/example/__tests__/viewmodel-properties.harness.ts
+++ b/example/__tests__/viewmodel-properties.harness.ts
@@ -174,23 +174,23 @@ describe('ViewModel Properties', () => {
     const instance = await createGordonInstance();
 
     await expect(
-      instance.numberProperty('nonexistent').getValueAsync()
+      instance.numberProperty('nonexistent')!.getValueAsync()
     ).rejects.toBeDefined();
 
     await expect(
-      instance.stringProperty('nonexistent').getValueAsync()
+      instance.stringProperty('nonexistent')!.getValueAsync()
     ).rejects.toBeDefined();
 
     await expect(
-      instance.booleanProperty('nonexistent').getValueAsync()
+      instance.booleanProperty('nonexistent')!.getValueAsync()
     ).rejects.toBeDefined();
 
     await expect(
-      instance.colorProperty('nonexistent').getValueAsync()
+      instance.colorProperty('nonexistent')!.getValueAsync()
     ).rejects.toBeDefined();
 
     await expect(
-      instance.enumProperty('nonexistent').getValueAsync()
+      instance.enumProperty('nonexistent')!.getValueAsync()
     ).rejects.toBeDefined();
   });
 });

--- a/example/__tests__/viewmodel-properties.harness.ts
+++ b/example/__tests__/viewmodel-properties.harness.ts
@@ -173,13 +173,25 @@ describe('ViewModel Properties', () => {
 
     const instance = await createGordonInstance();
 
-    const num = instance.numberProperty('nonexistent');
-    expectDefined(num);
-    await expect(num.getValueAsync()).rejects.toBeDefined();
+    await expect(
+      instance.numberProperty('nonexistent').getValueAsync()
+    ).rejects.toBeDefined();
 
-    const str = instance.stringProperty('nonexistent');
-    expectDefined(str);
-    await expect(str.getValueAsync()).rejects.toBeDefined();
+    await expect(
+      instance.stringProperty('nonexistent').getValueAsync()
+    ).rejects.toBeDefined();
+
+    await expect(
+      instance.booleanProperty('nonexistent').getValueAsync()
+    ).rejects.toBeDefined();
+
+    await expect(
+      instance.colorProperty('nonexistent').getValueAsync()
+    ).rejects.toBeDefined();
+
+    await expect(
+      instance.enumProperty('nonexistent').getValueAsync()
+    ).rejects.toBeDefined();
   });
 });
 


### PR DESCRIPTION
Property accessors (`numberProperty`, `stringProperty`, etc.) were using `runBlocking { flow.first() }` as an existence probe before returning the wrapper. This blocks the calling thread and can deadlock if called from the main thread (e.g. via a worklet).

The iOS experimental backend already does the right thing — it just creates and returns the wrapper directly. This PR aligns Android experimental to the same behaviour: return a wrapper always, fail lazily when `getValueAsync()` is called on an invalid path.

Also removes the `propertyNames` lazy val (used for `hasProperty`) which had its own one-time `runBlocking` call.

Test: updated guard for the "non-existent returns undefined" test (skips on all experimental backends), added new test asserting `getValueAsync()` rejects for invalid paths on experimental.