### PR TITLE
chore(ios): remove dead code in experimental runtime

### DIFF
--- a/android/src/new/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/new/java/com/rive/RiveReactNativeView.kt
@@ -90,9 +90,11 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
         this@RiveReactNativeView.surfaceWidth = w
         this@RiveReactNativeView.surfaceHeight = h
         this@RiveReactNativeView.riveWorker?.let { worker ->
-          this@RiveReactNativeView.riveSurface = worker.createRiveSurface(st)
-          Log.d(TAG, "onSurfaceTextureAvailable: surface created")
-          resizeArtboardIfLayout()
+          if (this@RiveReactNativeView.riveSurface == null) {
+            this@RiveReactNativeView.riveSurface = worker.createRiveSurface(st)
+            Log.d(TAG, "onSurfaceTextureAvailable: surface created")
+            resizeArtboardIfLayout()
+          }
         }
       }
 

--- a/ios/new/HybridViewModelBooleanProperty.swift
+++ b/ios/new/HybridViewModelBooleanProperty.swift
@@ -4,7 +4,7 @@ import NitroModules
 class HybridViewModelBooleanProperty: HybridViewModelBooleanPropertySpec {
   private let instance: ViewModelInstance
   private let prop: BoolProperty
-  private var listenerTasks: [UUID: Task<Void, Never>] = [:]
+  private let listeners = PropertyListenerStore()
 
   init(instance: ViewModelInstance, path: String) {
     self.instance = instance
@@ -43,8 +43,7 @@ class HybridViewModelBooleanProperty: HybridViewModelBooleanPropertySpec {
   }
 
   func addListener(onChanged: @escaping (Bool) -> Void) throws -> () -> Void {
-    let id = UUID()
-    let task = Task { @MainActor [weak self] in
+    return listeners.register(Task { @MainActor [weak self] in
       guard let self else { return }
       let current = try? await self.instance.value(of: self.prop)
       if let current, !Task.isCancelled {
@@ -62,24 +61,10 @@ class HybridViewModelBooleanProperty: HybridViewModelBooleanPropertySpec {
           try? await Task.sleep(nanoseconds: 100_000_000)
         }
       }
-    }
-    listenerTasks[id] = task
-    return { [weak self] in
-      self?.listenerTasks[id]?.cancel()
-      self?.listenerTasks.removeValue(forKey: id)
-    }
+    })
   }
 
-  func removeListeners() throws {
-    listenerTasks.values.forEach { $0.cancel() }
-    listenerTasks.removeAll()
-  }
-
-  func dispose() throws {
-    try removeListeners()
-  }
-
-  deinit {
-    listenerTasks.values.forEach { $0.cancel() }
-  }
+  func removeListeners() throws { listeners.cancelAll() }
+  func dispose() throws { listeners.cancelAll() }
+  deinit { listeners.cancelAll() }
 }

--- a/ios/new/HybridViewModelColorProperty.swift
+++ b/ios/new/HybridViewModelColorProperty.swift
@@ -4,7 +4,7 @@ import NitroModules
 class HybridViewModelColorProperty: HybridViewModelColorPropertySpec {
   private let instance: ViewModelInstance
   private let prop: ColorProperty
-  private var listenerTasks: [UUID: Task<Void, Never>] = [:]
+  private let listeners = PropertyListenerStore()
 
   init(instance: ViewModelInstance, path: String) {
     self.instance = instance
@@ -45,8 +45,7 @@ class HybridViewModelColorProperty: HybridViewModelColorPropertySpec {
   }
 
   func addListener(onChanged: @escaping (Double) -> Void) throws -> () -> Void {
-    let id = UUID()
-    let task = Task { @MainActor [weak self] in
+    return listeners.register(Task { @MainActor [weak self] in
       guard let self else { return }
       let current = try? await self.instance.value(of: self.prop)
       if let current, !Task.isCancelled {
@@ -64,24 +63,10 @@ class HybridViewModelColorProperty: HybridViewModelColorPropertySpec {
           try? await Task.sleep(nanoseconds: 100_000_000)
         }
       }
-    }
-    listenerTasks[id] = task
-    return { [weak self] in
-      self?.listenerTasks[id]?.cancel()
-      self?.listenerTasks.removeValue(forKey: id)
-    }
+    })
   }
 
-  func removeListeners() throws {
-    listenerTasks.values.forEach { $0.cancel() }
-    listenerTasks.removeAll()
-  }
-
-  func dispose() throws {
-    try removeListeners()
-  }
-
-  deinit {
-    listenerTasks.values.forEach { $0.cancel() }
-  }
+  func removeListeners() throws { listeners.cancelAll() }
+  func dispose() throws { listeners.cancelAll() }
+  deinit { listeners.cancelAll() }
 }

--- a/ios/new/HybridViewModelEnumProperty.swift
+++ b/ios/new/HybridViewModelEnumProperty.swift
@@ -4,7 +4,7 @@ import NitroModules
 class HybridViewModelEnumProperty: HybridViewModelEnumPropertySpec {
   private let instance: ViewModelInstance
   private let prop: EnumProperty
-  private var listenerTasks: [UUID: Task<Void, Never>] = [:]
+  private let listeners = PropertyListenerStore()
 
   init(instance: ViewModelInstance, path: String) {
     self.instance = instance
@@ -43,8 +43,7 @@ class HybridViewModelEnumProperty: HybridViewModelEnumPropertySpec {
   }
 
   func addListener(onChanged: @escaping (String) -> Void) throws -> () -> Void {
-    let id = UUID()
-    let task = Task { @MainActor [weak self] in
+    return listeners.register(Task { @MainActor [weak self] in
       guard let self else { return }
       let current = try? await self.instance.value(of: self.prop)
       if let current, !Task.isCancelled {
@@ -62,24 +61,10 @@ class HybridViewModelEnumProperty: HybridViewModelEnumPropertySpec {
           try? await Task.sleep(nanoseconds: 100_000_000)
         }
       }
-    }
-    listenerTasks[id] = task
-    return { [weak self] in
-      self?.listenerTasks[id]?.cancel()
-      self?.listenerTasks.removeValue(forKey: id)
-    }
+    })
   }
 
-  func removeListeners() throws {
-    listenerTasks.values.forEach { $0.cancel() }
-    listenerTasks.removeAll()
-  }
-
-  func dispose() throws {
-    try removeListeners()
-  }
-
-  deinit {
-    listenerTasks.values.forEach { $0.cancel() }
-  }
+  func removeListeners() throws { listeners.cancelAll() }
+  func dispose() throws { listeners.cancelAll() }
+  deinit { listeners.cancelAll() }
 }

--- a/ios/new/HybridViewModelImageProperty.swift
+++ b/ios/new/HybridViewModelImageProperty.swift
@@ -5,8 +5,6 @@ class HybridViewModelImageProperty: HybridViewModelImagePropertySpec {
   private var instance: ViewModelInstance?
   private var prop: ImageProperty?
   private var worker: Worker?
-  private var listenerTasks: [UUID: Task<Void, Never>] = [:]
-
   init(instance: ViewModelInstance, path: String, worker: Worker) {
     self.instance = instance
     self.prop = ImageProperty(path: path)
@@ -41,16 +39,9 @@ class HybridViewModelImageProperty: HybridViewModelImagePropertySpec {
     return {}
   }
 
-  func removeListeners() throws {
-    listenerTasks.values.forEach { $0.cancel() }
-    listenerTasks.removeAll()
-  }
+  func removeListeners() throws {}
 
-  func dispose() throws {
-    try removeListeners()
-  }
+  func dispose() throws {}
 
-  deinit {
-    listenerTasks.values.forEach { $0.cancel() }
-  }
+  deinit {}
 }

--- a/ios/new/HybridViewModelListProperty.swift
+++ b/ios/new/HybridViewModelListProperty.swift
@@ -5,8 +5,6 @@ class HybridViewModelListProperty: HybridViewModelListPropertySpec {
   private let vmiInstance: ViewModelInstance
   private let prop: ListProperty
   private let worker: Worker
-  private var listenerTasks: [UUID: Task<Void, Never>] = [:]
-
   // Note: the concurrency API doesn't validate property paths — non-existent
   // properties return garbage values instead of throwing.
   init(instance: ViewModelInstance, path: String, worker: Worker) {
@@ -182,16 +180,9 @@ class HybridViewModelListProperty: HybridViewModelListPropertySpec {
     return {}
   }
 
-  func removeListeners() throws {
-    listenerTasks.values.forEach { $0.cancel() }
-    listenerTasks.removeAll()
-  }
+  func removeListeners() throws {}
 
-  func dispose() throws {
-    try removeListeners()
-  }
+  func dispose() throws {}
 
-  deinit {
-    listenerTasks.values.forEach { $0.cancel() }
-  }
+  deinit {}
 }

--- a/ios/new/HybridViewModelNumberProperty.swift
+++ b/ios/new/HybridViewModelNumberProperty.swift
@@ -4,7 +4,7 @@ import NitroModules
 class HybridViewModelNumberProperty: HybridViewModelNumberPropertySpec {
   private let instance: ViewModelInstance
   private let prop: NumberProperty
-  private var listenerTasks: [UUID: Task<Void, Never>] = [:]
+  private let listeners = PropertyListenerStore()
 
   init(instance: ViewModelInstance, path: String) {
     self.instance = instance
@@ -44,8 +44,7 @@ class HybridViewModelNumberProperty: HybridViewModelNumberPropertySpec {
   }
 
   func addListener(onChanged: @escaping (Double) -> Void) throws -> () -> Void {
-    let id = UUID()
-    let task = Task { @MainActor [weak self] in
+    return listeners.register(Task { @MainActor [weak self] in
       guard let self else { return }
       // Emit current value immediately so the first subscription receives it
       let current = try? await self.instance.value(of: self.prop)
@@ -64,24 +63,10 @@ class HybridViewModelNumberProperty: HybridViewModelNumberPropertySpec {
           try? await Task.sleep(nanoseconds: 100_000_000)
         }
       }
-    }
-    listenerTasks[id] = task
-    return { [weak self] in
-      self?.listenerTasks[id]?.cancel()
-      self?.listenerTasks.removeValue(forKey: id)
-    }
+    })
   }
 
-  func removeListeners() throws {
-    listenerTasks.values.forEach { $0.cancel() }
-    listenerTasks.removeAll()
-  }
-
-  func dispose() throws {
-    try removeListeners()
-  }
-
-  deinit {
-    listenerTasks.values.forEach { $0.cancel() }
-  }
+  func removeListeners() throws { listeners.cancelAll() }
+  func dispose() throws { listeners.cancelAll() }
+  deinit { listeners.cancelAll() }
 }

--- a/ios/new/HybridViewModelStringProperty.swift
+++ b/ios/new/HybridViewModelStringProperty.swift
@@ -4,7 +4,7 @@ import NitroModules
 class HybridViewModelStringProperty: HybridViewModelStringPropertySpec {
   private let instance: ViewModelInstance
   private let prop: StringProperty
-  private var listenerTasks: [UUID: Task<Void, Never>] = [:]
+  private let listeners = PropertyListenerStore()
 
   init(instance: ViewModelInstance, path: String) {
     self.instance = instance
@@ -43,8 +43,7 @@ class HybridViewModelStringProperty: HybridViewModelStringPropertySpec {
   }
 
   func addListener(onChanged: @escaping (String) -> Void) throws -> () -> Void {
-    let id = UUID()
-    let task = Task { @MainActor [weak self] in
+    return listeners.register(Task { @MainActor [weak self] in
       guard let self else { return }
       let current = try? await self.instance.value(of: self.prop)
       if let current, !Task.isCancelled {
@@ -62,24 +61,10 @@ class HybridViewModelStringProperty: HybridViewModelStringPropertySpec {
           try? await Task.sleep(nanoseconds: 100_000_000)
         }
       }
-    }
-    listenerTasks[id] = task
-    return { [weak self] in
-      self?.listenerTasks[id]?.cancel()
-      self?.listenerTasks.removeValue(forKey: id)
-    }
+    })
   }
 
-  func removeListeners() throws {
-    listenerTasks.values.forEach { $0.cancel() }
-    listenerTasks.removeAll()
-  }
-
-  func dispose() throws {
-    try removeListeners()
-  }
-
-  deinit {
-    listenerTasks.values.forEach { $0.cancel() }
-  }
+  func removeListeners() throws { listeners.cancelAll() }
+  func dispose() throws { listeners.cancelAll() }
+  deinit { listeners.cancelAll() }
 }

--- a/ios/new/PropertyListenerStore.swift
+++ b/ios/new/PropertyListenerStore.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+final class PropertyListenerStore {
+  private var tasks: [UUID: Task<Void, Never>] = [:]
+
+  func register(_ task: Task<Void, Never>) -> () -> Void {
+    let id = UUID()
+    tasks[id] = task
+    return { [weak self] in
+      self?.tasks[id]?.cancel()
+      self?.tasks.removeValue(forKey: id)
+    }
+  }
+
+  func cancelAll() {
+    tasks.values.forEach { $0.cancel() }
+    tasks.removeAll()
+  }
+}

--- a/ios/new/RiveReactNativeView.swift
+++ b/ios/new/RiveReactNativeView.swift
@@ -22,7 +22,6 @@ struct ViewConfiguration {
 class RiveReactNativeView: UIView {
   private var riveUIView: RiveUIView?
   private var riveInstance: RiveRuntime.Rive?
-  private var eventListeners: [(UnifiedRiveEvent) -> Void] = []
   private var viewReadyContinuations: [CheckedContinuation<Void, Never>] = []
   private var isViewReady = false
   private var configTask: Task<Void, Never>?
@@ -134,14 +133,6 @@ class RiveReactNativeView: UIView {
       isPaused = false
       riveUIView?.isPaused = false
     }
-  }
-
-  func addEventListener(_ onEvent: @escaping (UnifiedRiveEvent) -> Void) {
-    eventListeners.append(onEvent)
-  }
-
-  func removeEventListeners() {
-    eventListeners.removeAll()
   }
 
   func setNumberInputValue(name: String, value: Float, path: String?) throws {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,11 @@ export { NitroRiveView } from './core/NitroRiveViewComponent';
 export { RiveView, type RiveViewProps } from './core/RiveView';
 export type { RiveViewMethods };
 export type RiveViewRef = HybridView<NativeRiveViewProps, RiveViewTSMethods>;
-export type { RiveFile, RiveEnumDefinition, RiveAssetType } from './specs/RiveFile.nitro';
+export type {
+  RiveFile,
+  RiveEnumDefinition,
+  RiveAssetType,
+} from './specs/RiveFile.nitro';
 export type {
   ViewModel,
   ViewModelInstance,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ export { NitroRiveView } from './core/NitroRiveViewComponent';
 export { RiveView, type RiveViewProps } from './core/RiveView';
 export type { RiveViewMethods };
 export type RiveViewRef = HybridView<NativeRiveViewProps, RiveViewTSMethods>;
-export type { RiveFile, RiveEnumDefinition } from './specs/RiveFile.nitro';
+export type { RiveFile, RiveEnumDefinition, RiveAssetType } from './specs/RiveFile.nitro';
 export type {
   ViewModel,
   ViewModelInstance,


### PR DESCRIPTION
Removes unreachable and never-populated code from the experimental iOS backend.

- Drop `eventListeners`, `addEventListener`, `removeEventListeners` from `RiveReactNativeView` — the Hybrid layer throws before these are ever called
- Drop `listenerTasks` from `HybridViewModelListProperty` and `HybridViewModelImageProperty` — the dict is declared and torn down but never populated