### PR TITLE
feat: add setValueAsync to all scalar ViewModel property types

### DIFF
--- a/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelBooleanProperty.kt
+++ b/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelBooleanProperty.kt
@@ -24,6 +24,10 @@ class HybridViewModelBooleanProperty(private val viewModelBoolean: ViewModelBool
     viewModelBoolean.value = value
   }
 
+  override fun setValueAsync(value: Boolean): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun addListener(onChanged: (value: Boolean) -> Unit): () -> Unit {
     val remover = addListenerInternal(onChanged)
     ensureValueListenerJob(viewModelBoolean.valueFlow)

--- a/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelColorProperty.kt
+++ b/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelColorProperty.kt
@@ -24,6 +24,10 @@ class HybridViewModelColorProperty(private val viewModelColor: ViewModelColorPro
     viewModelColor.value = value.toLong().toInt()
   }
 
+  override fun setValueAsync(value: Double): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun addListener(onChanged: (value: Double) -> Unit): () -> Unit {
     val remover = addListenerInternal { intValue: Int -> onChanged(intValue.toDouble()) }
     ensureValueListenerJob(viewModelColor.valueFlow)

--- a/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelEnumProperty.kt
+++ b/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelEnumProperty.kt
@@ -24,6 +24,10 @@ class HybridViewModelEnumProperty(private val viewModelEnum: ViewModelEnumProper
     viewModelEnum.value = value
   }
 
+  override fun setValueAsync(value: String): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun addListener(onChanged: (value: String) -> Unit): () -> Unit {
     val remover = addListenerInternal(onChanged)
     ensureValueListenerJob(viewModelEnum.valueFlow)

--- a/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelNumberProperty.kt
+++ b/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelNumberProperty.kt
@@ -25,6 +25,10 @@ class HybridViewModelNumberProperty(private val viewModelNumber: ViewModelNumber
     viewModelNumber.value = value.toFloat()
   }
 
+  override fun setValueAsync(value: Double): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun addListener(onChanged: (value: Double) -> Unit): () -> Unit {
     val remover = addListenerInternal(onChanged)
     ensureValueListenerJob(viewModelNumber.valueFlow.map { it.toDouble() })

--- a/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelStringProperty.kt
+++ b/android/src/legacy/java/com/margelo/nitro/rive/HybridViewModelStringProperty.kt
@@ -24,6 +24,10 @@ class HybridViewModelStringProperty(private val viewModelString: ViewModelString
     viewModelString.value = value
   }
 
+  override fun setValueAsync(value: String): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun addListener(onChanged: (value: String) -> Unit): () -> Unit {
     val remover = addListenerInternal(onChanged)
     ensureValueListenerJob(viewModelString.valueFlow)

--- a/android/src/new/java/com/margelo/nitro/rive/HybridViewModel.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridViewModel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.runBlocking
 class HybridViewModel(
   private val riveFile: RiveFile,
   private val riveWorker: CommandQueue,
-  private val viewModelName: String?,
+  private val viewModelName: String,
   private val parentFile: HybridRiveFile,
   private val vmSource: ViewModelSource
 ) : HybridViewModelSpec() {
@@ -24,10 +24,9 @@ class HybridViewModel(
   }
 
   override fun getPropertiesAsync(): Promise<Array<ViewModelPropertyInfo>> {
-    val name = viewModelName ?: return Promise.resolved(emptyArray())
     return Promise.async {
       riveFile
-        .getViewModelProperties(name)
+        .getViewModelProperties(viewModelName)
         .map { prop ->
         ViewModelPropertyInfo(name = prop.name, type = mapPropertyType(prop.type))
       }.toTypedArray()
@@ -37,9 +36,8 @@ class HybridViewModel(
   override val propertyCount: Double
     get() {
       DeprecationWarning.warn("propertyCount", "getPropertyCountAsync")
-      val name = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
       return try {
-        runBlocking { riveFile.getViewModelProperties(name) }.size.toDouble()
+        runBlocking { riveFile.getViewModelProperties(viewModelName) }.size.toDouble()
       } catch (e: Exception) {
         RiveLog.e(TAG, "propertyCount failed: ${e.message}")
         0.0
@@ -49,9 +47,8 @@ class HybridViewModel(
   override val instanceCount: Double
     get() {
       DeprecationWarning.warn("instanceCount", "getInstanceCountAsync")
-      val name = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
       return try {
-        runBlocking { riveFile.getViewModelInstanceNames(name) }.size.toDouble()
+        runBlocking { riveFile.getViewModelInstanceNames(viewModelName) }.size.toDouble()
       } catch (e: Exception) {
         RiveLog.e(TAG, "instanceCount failed: ${e.message}")
         0.0
@@ -59,30 +56,25 @@ class HybridViewModel(
     }
 
   override val modelName: String
-    get() = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
+    get() = viewModelName
 
   override fun getPropertyCountAsync(): Promise<Double> {
-    val name = viewModelName ?: return Promise.rejected(UnsupportedOperationException("ViewModel name is unavailable"))
-    return Promise.async { riveFile.getViewModelProperties(name).size.toDouble() }
+    return Promise.async { riveFile.getViewModelProperties(viewModelName).size.toDouble() }
   }
 
   override fun getInstanceCountAsync(): Promise<Double> {
-    val name = viewModelName ?: return Promise.rejected(UnsupportedOperationException("ViewModel name is unavailable"))
-    return Promise.async { riveFile.getViewModelInstanceNames(name).size.toDouble() }
+    return Promise.async { riveFile.getViewModelInstanceNames(viewModelName).size.toDouble() }
   }
 
   // Deprecated: Use createInstanceByNameAsync instead
   override fun createInstanceByIndex(index: Double): HybridViewModelInstanceSpec? {
     DeprecationWarning.warn("createInstanceByIndex", "createInstanceByNameAsync")
-    val name = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
     return try {
       val idx = index.toInt()
-      val instanceNames = runBlocking { riveFile.getViewModelInstanceNames(name) }
+      val instanceNames = runBlocking { riveFile.getViewModelInstanceNames(viewModelName) }
       if (idx < 0 || idx >= instanceNames.size) return null
       val instanceName = instanceNames[idx]
       runBlocking { createInstanceByNameImpl(instanceName) }
-    } catch (e: UnsupportedOperationException) {
-      throw e
     } catch (e: Exception) {
       RiveLog.e(TAG, "createInstanceByIndex($index) failed: ${e.message}")
       null
@@ -90,22 +82,18 @@ class HybridViewModel(
   }
 
   private suspend fun createInstanceByNameImpl(instanceName: String): HybridViewModelInstanceSpec? {
-    val name = viewModelName ?: throw UnsupportedOperationException("ViewModel name is unavailable")
-    val instanceNames = riveFile.getViewModelInstanceNames(name)
+    val instanceNames = riveFile.getViewModelInstanceNames(viewModelName)
     if (!instanceNames.contains(instanceName)) return null
     val source = vmSource.namedInstance(instanceName)
     val vmi = ViewModelInstance.fromFile(riveFile, source)
-    return HybridViewModelInstance(vmi, riveWorker, parentFile, name, instanceName)
+    return HybridViewModelInstance(vmi, riveWorker, parentFile, viewModelName, instanceName)
   }
 
   // Deprecated: Use createInstanceByNameAsync instead
   override fun createInstanceByName(name: String): HybridViewModelInstanceSpec? {
     DeprecationWarning.warn("createInstanceByName", "createInstanceByNameAsync")
-    if (viewModelName == null) throw UnsupportedOperationException("ViewModel name is unavailable")
     return try {
       runBlocking { createInstanceByNameImpl(name) }
-    } catch (e: UnsupportedOperationException) {
-      throw e
     } catch (e: Exception) {
       RiveLog.e(TAG, "createInstanceByName('$name') failed: ${e.message}")
       null
@@ -113,7 +101,6 @@ class HybridViewModel(
   }
 
   override fun createInstanceByNameAsync(name: String): Promise<HybridViewModelInstanceSpec?> {
-    if (viewModelName == null) return Promise.rejected(UnsupportedOperationException("ViewModel name is unavailable"))
     return Promise.async { createInstanceByNameImpl(name) }
   }
 

--- a/android/src/new/java/com/margelo/nitro/rive/HybridViewModelBooleanProperty.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridViewModelBooleanProperty.kt
@@ -37,6 +37,10 @@ class HybridViewModelBooleanProperty(
     instance.setBoolean(path, value)
   }
 
+  override fun setValueAsync(value: Boolean): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun getValueAsync(): Promise<Boolean> {
     return Promise.async { instance.getBooleanFlow(path).first() }
   }

--- a/android/src/new/java/com/margelo/nitro/rive/HybridViewModelColorProperty.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridViewModelColorProperty.kt
@@ -37,6 +37,10 @@ class HybridViewModelColorProperty(
     instance.setColor(path, value.toLong().toInt())
   }
 
+  override fun setValueAsync(value: Double): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun getValueAsync(): Promise<Double> {
     return Promise.async { instance.getColorFlow(path).first().toDouble() }
   }

--- a/android/src/new/java/com/margelo/nitro/rive/HybridViewModelEnumProperty.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridViewModelEnumProperty.kt
@@ -37,6 +37,10 @@ class HybridViewModelEnumProperty(
     instance.setEnum(path, value)
   }
 
+  override fun setValueAsync(value: String): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun getValueAsync(): Promise<String> {
     return Promise.async { instance.getEnumFlow(path).first() }
   }

--- a/android/src/new/java/com/margelo/nitro/rive/HybridViewModelNumberProperty.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridViewModelNumberProperty.kt
@@ -37,6 +37,10 @@ class HybridViewModelNumberProperty(
     instance.setNumber(path, value.toFloat())
   }
 
+  override fun setValueAsync(value: Double): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun getValueAsync(): Promise<Double> {
     return Promise.async { instance.getNumberFlow(path).first().toDouble() }
   }

--- a/android/src/new/java/com/margelo/nitro/rive/HybridViewModelStringProperty.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridViewModelStringProperty.kt
@@ -37,6 +37,10 @@ class HybridViewModelStringProperty(
     instance.setString(path, value)
   }
 
+  override fun setValueAsync(value: String): Promise<Unit> {
+    return Promise.async { set(value) }
+  }
+
   override fun getValueAsync(): Promise<String> {
     return Promise.async { instance.getStringFlow(path).first() }
   }

--- a/example/__tests__/viewmodel-properties.harness.ts
+++ b/example/__tests__/viewmodel-properties.harness.ts
@@ -444,6 +444,49 @@ describe('set() + getValueAsync() round-trip', () => {
   });
 });
 
+describe('setValueAsync() updates value', () => {
+  it('numberProperty setValueAsync updates value', async () => {
+    const instance = await createGordonInstance();
+    const prop = instance.numberProperty('age');
+    expectDefined(prop);
+    await prop.setValueAsync(42);
+    expect(await prop.getValueAsync()).toBe(42);
+  });
+
+  it('stringProperty setValueAsync updates value', async () => {
+    const instance = await createGordonInstance();
+    const prop = instance.stringProperty('name');
+    expectDefined(prop);
+    await prop.setValueAsync('Alice');
+    expect(await prop.getValueAsync()).toBe('Alice');
+  });
+
+  it('booleanProperty setValueAsync updates value', async () => {
+    const instance = await createGordonInstance();
+    const prop = instance.booleanProperty('likes_popcorn');
+    expectDefined(prop);
+    await prop.setValueAsync(true);
+    expect(await prop.getValueAsync()).toBe(true);
+  });
+
+  it('colorProperty setValueAsync updates value', async () => {
+    const instance = await createGordonInstance();
+    const prop = instance.colorProperty('favourite_color');
+    expectDefined(prop);
+    await prop.setValueAsync(0xff00ff00);
+    const rgb = getRGB(await prop.getValueAsync());
+    expect(rgb).toEqual({ r: 0, g: 255, b: 0 });
+  });
+
+  it('enumProperty setValueAsync updates value', async () => {
+    const instance = await createGordonInstance();
+    const prop = instance.enumProperty('favourite_pet');
+    expectDefined(prop);
+    await prop.setValueAsync('cat');
+    expect(await prop.getValueAsync()).toBe('cat');
+  });
+});
+
 describe('removeListeners stops callbacks', () => {
   it('no callbacks fire after removeListeners', async () => {
     const instance = await createGordonInstance();

--- a/ios/legacy/HybridViewModelBooleanProperty.swift
+++ b/ios/legacy/HybridViewModelBooleanProperty.swift
@@ -26,4 +26,8 @@ class HybridViewModelBooleanProperty: HybridViewModelBooleanPropertySpec, Valued
   func set(value: Bool) throws {
     property.value = value
   }
+
+  func setValueAsync(value: Bool) throws -> Promise<Void> {
+    return Promise.async { self.property.value = value }
+  }
 }

--- a/ios/legacy/HybridViewModelColorProperty.swift
+++ b/ios/legacy/HybridViewModelColorProperty.swift
@@ -27,6 +27,11 @@ class HybridViewModelColorProperty: HybridViewModelColorPropertySpec, ValuedProp
     property.value = UIColor(argb: Int(value))
   }
 
+  func setValueAsync(value: Double) throws -> Promise<Void> {
+    let color = UIColor(argb: Int(value))
+    return Promise.async { self.property.value = color }
+  }
+
   func addListener(onChanged: @escaping (Double) -> Void) throws -> () -> Void {
     return helper.addListener { (color: UIColor) in
       onChanged(color.toHexDouble())

--- a/ios/legacy/HybridViewModelEnumProperty.swift
+++ b/ios/legacy/HybridViewModelEnumProperty.swift
@@ -26,4 +26,8 @@ class HybridViewModelEnumProperty: HybridViewModelEnumPropertySpec, ValuedProper
   func set(value: String) throws {
     property.value = value
   }
+
+  func setValueAsync(value: String) throws -> Promise<Void> {
+    return Promise.async { self.property.value = value }
+  }
 }

--- a/ios/legacy/HybridViewModelNumberProperty.swift
+++ b/ios/legacy/HybridViewModelNumberProperty.swift
@@ -27,6 +27,11 @@ class HybridViewModelNumberProperty: HybridViewModelNumberPropertySpec, ValuedPr
     property.value = Float(value)
   }
 
+  func setValueAsync(value: Double) throws -> Promise<Void> {
+    let v = Float(value)
+    return Promise.async { self.property.value = v }
+  }
+
   func addListener(onChanged: @escaping (Double) -> Void) throws -> () -> Void {
     return helper.addListener({ floatValue in onChanged(Double(floatValue)) })
   }

--- a/ios/legacy/HybridViewModelStringProperty.swift
+++ b/ios/legacy/HybridViewModelStringProperty.swift
@@ -26,4 +26,8 @@ class HybridViewModelStringProperty: HybridViewModelStringPropertySpec, ValuedPr
   func set(value: String) throws {
     property.value = value
   }
+
+  func setValueAsync(value: String) throws -> Promise<Void> {
+    return Promise.async { self.property.value = value }
+  }
 }

--- a/ios/new/HybridViewModelBooleanProperty.swift
+++ b/ios/new/HybridViewModelBooleanProperty.swift
@@ -34,6 +34,14 @@ class HybridViewModelBooleanProperty: HybridViewModelBooleanPropertySpec {
     }
   }
 
+  func setValueAsync(value: Bool) throws -> Promise<Void> {
+    let inst = instance
+    let p = prop
+    return Promise.async { @MainActor in
+      inst.setValue(of: p, to: value)
+    }
+  }
+
   func getValueAsync() throws -> Promise<Bool> {
     let inst = instance
     let p = prop

--- a/ios/new/HybridViewModelColorProperty.swift
+++ b/ios/new/HybridViewModelColorProperty.swift
@@ -40,6 +40,15 @@ class HybridViewModelColorProperty: HybridViewModelColorPropertySpec {
     }
   }
 
+  func setValueAsync(value: Double) throws -> Promise<Void> {
+    let color = Color(UInt32(truncatingIfNeeded: Int64(value)))
+    let inst = instance
+    let p = prop
+    return Promise.async { @MainActor in
+      inst.setValue(of: p, to: color)
+    }
+  }
+
   func getValueAsync() throws -> Promise<Double> {
     return Promise.async { try await self.fetchColorValue() }
   }

--- a/ios/new/HybridViewModelEnumProperty.swift
+++ b/ios/new/HybridViewModelEnumProperty.swift
@@ -34,6 +34,14 @@ class HybridViewModelEnumProperty: HybridViewModelEnumPropertySpec {
     }
   }
 
+  func setValueAsync(value: String) throws -> Promise<Void> {
+    let inst = instance
+    let p = prop
+    return Promise.async { @MainActor in
+      inst.setValue(of: p, to: value)
+    }
+  }
+
   func getValueAsync() throws -> Promise<String> {
     let inst = instance
     let p = prop

--- a/ios/new/HybridViewModelNumberProperty.swift
+++ b/ios/new/HybridViewModelNumberProperty.swift
@@ -35,6 +35,15 @@ class HybridViewModelNumberProperty: HybridViewModelNumberPropertySpec {
     }
   }
 
+  func setValueAsync(value: Double) throws -> Promise<Void> {
+    let inst = instance
+    let p = prop
+    let v = Float(value)
+    return Promise.async { @MainActor in
+      inst.setValue(of: p, to: v)
+    }
+  }
+
   func getValueAsync() throws -> Promise<Double> {
     let inst = instance
     let p = prop

--- a/ios/new/HybridViewModelStringProperty.swift
+++ b/ios/new/HybridViewModelStringProperty.swift
@@ -34,6 +34,14 @@ class HybridViewModelStringProperty: HybridViewModelStringPropertySpec {
     }
   }
 
+  func setValueAsync(value: String) throws -> Promise<Void> {
+    let inst = instance
+    let p = prop
+    return Promise.async { @MainActor in
+      inst.setValue(of: p, to: value)
+    }
+  }
+
   func getValueAsync() throws -> Promise<String> {
     let inst = instance
     let p = prop

--- a/nitrogen/generated/android/c++/JHybridViewModelBooleanPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelBooleanPropertySpec.cpp
@@ -11,6 +11,7 @@
 
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/JPromise.hpp>
+#include <NitroModules/JUnit.hpp>
 #include <functional>
 #include "JFunc_void.hpp"
 #include <NitroModules/JNICallable.hpp>
@@ -76,6 +77,21 @@ namespace margelo::nitro::rive {
   void JHybridViewModelBooleanPropertySpec::set(bool value) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jboolean /* value */)>("set");
     method(_javaPart, value);
+  }
+  std::shared_ptr<Promise<void>> JHybridViewModelBooleanPropertySpec::setValueAsync(bool value) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jboolean /* value */)>("setValueAsync");
+    auto __result = method(_javaPart, value);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::function<void()> JHybridViewModelBooleanPropertySpec::addListener(const std::function<void(bool /* value */)>& onChanged) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_bool::javaobject> /* onChanged */)>("addListener_cxx");

--- a/nitrogen/generated/android/c++/JHybridViewModelBooleanPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelBooleanPropertySpec.hpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::rive {
     // Methods
     std::shared_ptr<Promise<bool>> getValueAsync() override;
     void set(bool value) override;
+    std::shared_ptr<Promise<void>> setValueAsync(bool value) override;
     std::function<void()> addListener(const std::function<void(bool /* value */)>& onChanged) override;
     void removeListeners() override;
 

--- a/nitrogen/generated/android/c++/JHybridViewModelColorPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelColorPropertySpec.cpp
@@ -11,6 +11,7 @@
 
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/JPromise.hpp>
+#include <NitroModules/JUnit.hpp>
 #include <functional>
 #include "JFunc_void.hpp"
 #include <NitroModules/JNICallable.hpp>
@@ -76,6 +77,21 @@ namespace margelo::nitro::rive {
   void JHybridViewModelColorPropertySpec::set(double value) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(double /* value */)>("set");
     method(_javaPart, value);
+  }
+  std::shared_ptr<Promise<void>> JHybridViewModelColorPropertySpec::setValueAsync(double value) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(double /* value */)>("setValueAsync");
+    auto __result = method(_javaPart, value);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::function<void()> JHybridViewModelColorPropertySpec::addListener(const std::function<void(double /* value */)>& onChanged) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_double::javaobject> /* onChanged */)>("addListener_cxx");

--- a/nitrogen/generated/android/c++/JHybridViewModelColorPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelColorPropertySpec.hpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::rive {
     // Methods
     std::shared_ptr<Promise<double>> getValueAsync() override;
     void set(double value) override;
+    std::shared_ptr<Promise<void>> setValueAsync(double value) override;
     std::function<void()> addListener(const std::function<void(double /* value */)>& onChanged) override;
     void removeListeners() override;
 

--- a/nitrogen/generated/android/c++/JHybridViewModelEnumPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelEnumPropertySpec.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/JPromise.hpp>
+#include <NitroModules/JUnit.hpp>
 #include <functional>
 #include "JFunc_void.hpp"
 #include <NitroModules/JNICallable.hpp>
@@ -77,6 +78,21 @@ namespace margelo::nitro::rive {
   void JHybridViewModelEnumPropertySpec::set(const std::string& value) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* value */)>("set");
     method(_javaPart, jni::make_jstring(value));
+  }
+  std::shared_ptr<Promise<void>> JHybridViewModelEnumPropertySpec::setValueAsync(const std::string& value) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* value */)>("setValueAsync");
+    auto __result = method(_javaPart, jni::make_jstring(value));
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::function<void()> JHybridViewModelEnumPropertySpec::addListener(const std::function<void(const std::string& /* value */)>& onChanged) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_std__string::javaobject> /* onChanged */)>("addListener_cxx");

--- a/nitrogen/generated/android/c++/JHybridViewModelEnumPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelEnumPropertySpec.hpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::rive {
     // Methods
     std::shared_ptr<Promise<std::string>> getValueAsync() override;
     void set(const std::string& value) override;
+    std::shared_ptr<Promise<void>> setValueAsync(const std::string& value) override;
     std::function<void()> addListener(const std::function<void(const std::string& /* value */)>& onChanged) override;
     void removeListeners() override;
 

--- a/nitrogen/generated/android/c++/JHybridViewModelNumberPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelNumberPropertySpec.cpp
@@ -11,6 +11,7 @@
 
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/JPromise.hpp>
+#include <NitroModules/JUnit.hpp>
 #include <functional>
 #include "JFunc_void.hpp"
 #include <NitroModules/JNICallable.hpp>
@@ -76,6 +77,21 @@ namespace margelo::nitro::rive {
   void JHybridViewModelNumberPropertySpec::set(double value) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(double /* value */)>("set");
     method(_javaPart, value);
+  }
+  std::shared_ptr<Promise<void>> JHybridViewModelNumberPropertySpec::setValueAsync(double value) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(double /* value */)>("setValueAsync");
+    auto __result = method(_javaPart, value);
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::function<void()> JHybridViewModelNumberPropertySpec::addListener(const std::function<void(double /* value */)>& onChanged) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_double::javaobject> /* onChanged */)>("addListener_cxx");

--- a/nitrogen/generated/android/c++/JHybridViewModelNumberPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelNumberPropertySpec.hpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::rive {
     // Methods
     std::shared_ptr<Promise<double>> getValueAsync() override;
     void set(double value) override;
+    std::shared_ptr<Promise<void>> setValueAsync(double value) override;
     std::function<void()> addListener(const std::function<void(double /* value */)>& onChanged) override;
     void removeListeners() override;
 

--- a/nitrogen/generated/android/c++/JHybridViewModelStringPropertySpec.cpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelStringPropertySpec.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <NitroModules/Promise.hpp>
 #include <NitroModules/JPromise.hpp>
+#include <NitroModules/JUnit.hpp>
 #include <functional>
 #include "JFunc_void.hpp"
 #include <NitroModules/JNICallable.hpp>
@@ -77,6 +78,21 @@ namespace margelo::nitro::rive {
   void JHybridViewModelStringPropertySpec::set(const std::string& value) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<void(jni::alias_ref<jni::JString> /* value */)>("set");
     method(_javaPart, jni::make_jstring(value));
+  }
+  std::shared_ptr<Promise<void>> JHybridViewModelStringPropertySpec::setValueAsync(const std::string& value) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JPromise::javaobject>(jni::alias_ref<jni::JString> /* value */)>("setValueAsync");
+    auto __result = method(_javaPart, jni::make_jstring(value));
+    return [&]() {
+      auto __promise = Promise<void>::create();
+      __result->cthis()->addOnResolvedListener([=](const jni::alias_ref<jni::JObject>& /* unit */) {
+        __promise->resolve();
+      });
+      __result->cthis()->addOnRejectedListener([=](const jni::alias_ref<jni::JThrowable>& __throwable) {
+        jni::JniException __jniError(__throwable);
+        __promise->reject(std::make_exception_ptr(__jniError));
+      });
+      return __promise;
+    }();
   }
   std::function<void()> JHybridViewModelStringPropertySpec::addListener(const std::function<void(const std::string& /* value */)>& onChanged) {
     static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JFunc_void::javaobject>(jni::alias_ref<JFunc_void_std__string::javaobject> /* onChanged */)>("addListener_cxx");

--- a/nitrogen/generated/android/c++/JHybridViewModelStringPropertySpec.hpp
+++ b/nitrogen/generated/android/c++/JHybridViewModelStringPropertySpec.hpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::rive {
     // Methods
     std::shared_ptr<Promise<std::string>> getValueAsync() override;
     void set(const std::string& value) override;
+    std::shared_ptr<Promise<void>> setValueAsync(const std::string& value) override;
     std::function<void()> addListener(const std::function<void(const std::string& /* value */)>& onChanged) override;
     void removeListeners() override;
 

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelBooleanPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelBooleanPropertySpec.kt
@@ -41,6 +41,10 @@ abstract class HybridViewModelBooleanPropertySpec: HybridViewModelPropertySpec()
   @Keep
   abstract fun set(value: Boolean): Unit
   
+  @DoNotStrip
+  @Keep
+  abstract fun setValueAsync(value: Boolean): Promise<Unit>
+  
   abstract fun addListener(onChanged: (value: Boolean) -> Unit): () -> Unit
   
   @DoNotStrip

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelColorPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelColorPropertySpec.kt
@@ -41,6 +41,10 @@ abstract class HybridViewModelColorPropertySpec: HybridViewModelPropertySpec() {
   @Keep
   abstract fun set(value: Double): Unit
   
+  @DoNotStrip
+  @Keep
+  abstract fun setValueAsync(value: Double): Promise<Unit>
+  
   abstract fun addListener(onChanged: (value: Double) -> Unit): () -> Unit
   
   @DoNotStrip

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelEnumPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelEnumPropertySpec.kt
@@ -41,6 +41,10 @@ abstract class HybridViewModelEnumPropertySpec: HybridViewModelPropertySpec() {
   @Keep
   abstract fun set(value: String): Unit
   
+  @DoNotStrip
+  @Keep
+  abstract fun setValueAsync(value: String): Promise<Unit>
+  
   abstract fun addListener(onChanged: (value: String) -> Unit): () -> Unit
   
   @DoNotStrip

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelNumberPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelNumberPropertySpec.kt
@@ -41,6 +41,10 @@ abstract class HybridViewModelNumberPropertySpec: HybridViewModelPropertySpec() 
   @Keep
   abstract fun set(value: Double): Unit
   
+  @DoNotStrip
+  @Keep
+  abstract fun setValueAsync(value: Double): Promise<Unit>
+  
   abstract fun addListener(onChanged: (value: Double) -> Unit): () -> Unit
   
   @DoNotStrip

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelStringPropertySpec.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/rive/HybridViewModelStringPropertySpec.kt
@@ -41,6 +41,10 @@ abstract class HybridViewModelStringPropertySpec: HybridViewModelPropertySpec() 
   @Keep
   abstract fun set(value: String): Unit
   
+  @DoNotStrip
+  @Keep
+  abstract fun setValueAsync(value: String): Promise<Unit>
+  
   abstract fun addListener(onChanged: (value: String) -> Unit): () -> Unit
   
   @DoNotStrip

--- a/nitrogen/generated/ios/c++/HybridViewModelBooleanPropertySpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridViewModelBooleanPropertySpecSwift.hpp
@@ -89,6 +89,14 @@ namespace margelo::nitro::rive {
         std::rethrow_exception(__result.error());
       }
     }
+    inline std::shared_ptr<Promise<void>> setValueAsync(bool value) override {
+      auto __result = _swiftPart.setValueAsync(std::forward<decltype(value)>(value));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::function<void()> addListener(const std::function<void(bool /* value */)>& onChanged) override {
       auto __result = _swiftPart.addListener(onChanged);
       if (__result.hasError()) [[unlikely]] {

--- a/nitrogen/generated/ios/c++/HybridViewModelColorPropertySpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridViewModelColorPropertySpecSwift.hpp
@@ -89,6 +89,14 @@ namespace margelo::nitro::rive {
         std::rethrow_exception(__result.error());
       }
     }
+    inline std::shared_ptr<Promise<void>> setValueAsync(double value) override {
+      auto __result = _swiftPart.setValueAsync(std::forward<decltype(value)>(value));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::function<void()> addListener(const std::function<void(double /* value */)>& onChanged) override {
       auto __result = _swiftPart.addListener(onChanged);
       if (__result.hasError()) [[unlikely]] {

--- a/nitrogen/generated/ios/c++/HybridViewModelEnumPropertySpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridViewModelEnumPropertySpecSwift.hpp
@@ -91,6 +91,14 @@ namespace margelo::nitro::rive {
         std::rethrow_exception(__result.error());
       }
     }
+    inline std::shared_ptr<Promise<void>> setValueAsync(const std::string& value) override {
+      auto __result = _swiftPart.setValueAsync(value);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::function<void()> addListener(const std::function<void(const std::string& /* value */)>& onChanged) override {
       auto __result = _swiftPart.addListener(onChanged);
       if (__result.hasError()) [[unlikely]] {

--- a/nitrogen/generated/ios/c++/HybridViewModelNumberPropertySpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridViewModelNumberPropertySpecSwift.hpp
@@ -89,6 +89,14 @@ namespace margelo::nitro::rive {
         std::rethrow_exception(__result.error());
       }
     }
+    inline std::shared_ptr<Promise<void>> setValueAsync(double value) override {
+      auto __result = _swiftPart.setValueAsync(std::forward<decltype(value)>(value));
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::function<void()> addListener(const std::function<void(double /* value */)>& onChanged) override {
       auto __result = _swiftPart.addListener(onChanged);
       if (__result.hasError()) [[unlikely]] {

--- a/nitrogen/generated/ios/c++/HybridViewModelStringPropertySpecSwift.hpp
+++ b/nitrogen/generated/ios/c++/HybridViewModelStringPropertySpecSwift.hpp
@@ -91,6 +91,14 @@ namespace margelo::nitro::rive {
         std::rethrow_exception(__result.error());
       }
     }
+    inline std::shared_ptr<Promise<void>> setValueAsync(const std::string& value) override {
+      auto __result = _swiftPart.setValueAsync(value);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
     inline std::function<void()> addListener(const std::function<void(const std::string& /* value */)>& onChanged) override {
       auto __result = _swiftPart.addListener(onChanged);
       if (__result.hasError()) [[unlikely]] {

--- a/nitrogen/generated/ios/swift/HybridViewModelBooleanPropertySpec.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelBooleanPropertySpec.swift
@@ -15,6 +15,7 @@ public protocol HybridViewModelBooleanPropertySpec_protocol: HybridObject, Hybri
   // Methods
   func getValueAsync() throws -> Promise<Bool>
   func set(value: Bool) throws -> Void
+  func setValueAsync(value: Bool) throws -> Promise<Void>
   func addListener(onChanged: @escaping (_ value: Bool) -> Void) throws -> () -> Void
   func removeListeners() throws -> Void
 }

--- a/nitrogen/generated/ios/swift/HybridViewModelBooleanPropertySpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelBooleanPropertySpec_cxx.swift
@@ -167,6 +167,25 @@ open class HybridViewModelBooleanPropertySpec_cxx : HybridViewModelPropertySpec_
   }
   
   @inline(__always)
+  public final func setValueAsync(value: Bool) -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.setValueAsync(value: value)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func addListener(onChanged: bridge.Func_void_bool) -> bridge.Result_std__function_void____ {
     do {
       let __result = try self.__implementation.addListener(onChanged: { () -> (Bool) -> Void in

--- a/nitrogen/generated/ios/swift/HybridViewModelColorPropertySpec.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelColorPropertySpec.swift
@@ -15,6 +15,7 @@ public protocol HybridViewModelColorPropertySpec_protocol: HybridObject, HybridV
   // Methods
   func getValueAsync() throws -> Promise<Double>
   func set(value: Double) throws -> Void
+  func setValueAsync(value: Double) throws -> Promise<Void>
   func addListener(onChanged: @escaping (_ value: Double) -> Void) throws -> () -> Void
   func removeListeners() throws -> Void
 }

--- a/nitrogen/generated/ios/swift/HybridViewModelColorPropertySpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelColorPropertySpec_cxx.swift
@@ -167,6 +167,25 @@ open class HybridViewModelColorPropertySpec_cxx : HybridViewModelPropertySpec_cx
   }
   
   @inline(__always)
+  public final func setValueAsync(value: Double) -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.setValueAsync(value: value)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func addListener(onChanged: bridge.Func_void_double) -> bridge.Result_std__function_void____ {
     do {
       let __result = try self.__implementation.addListener(onChanged: { () -> (Double) -> Void in

--- a/nitrogen/generated/ios/swift/HybridViewModelEnumPropertySpec.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelEnumPropertySpec.swift
@@ -15,6 +15,7 @@ public protocol HybridViewModelEnumPropertySpec_protocol: HybridObject, HybridVi
   // Methods
   func getValueAsync() throws -> Promise<String>
   func set(value: String) throws -> Void
+  func setValueAsync(value: String) throws -> Promise<Void>
   func addListener(onChanged: @escaping (_ value: String) -> Void) throws -> () -> Void
   func removeListeners() throws -> Void
 }

--- a/nitrogen/generated/ios/swift/HybridViewModelEnumPropertySpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelEnumPropertySpec_cxx.swift
@@ -167,6 +167,25 @@ open class HybridViewModelEnumPropertySpec_cxx : HybridViewModelPropertySpec_cxx
   }
   
   @inline(__always)
+  public final func setValueAsync(value: std.string) -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.setValueAsync(value: String(value))
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func addListener(onChanged: bridge.Func_void_std__string) -> bridge.Result_std__function_void____ {
     do {
       let __result = try self.__implementation.addListener(onChanged: { () -> (String) -> Void in

--- a/nitrogen/generated/ios/swift/HybridViewModelNumberPropertySpec.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelNumberPropertySpec.swift
@@ -15,6 +15,7 @@ public protocol HybridViewModelNumberPropertySpec_protocol: HybridObject, Hybrid
   // Methods
   func getValueAsync() throws -> Promise<Double>
   func set(value: Double) throws -> Void
+  func setValueAsync(value: Double) throws -> Promise<Void>
   func addListener(onChanged: @escaping (_ value: Double) -> Void) throws -> () -> Void
   func removeListeners() throws -> Void
 }

--- a/nitrogen/generated/ios/swift/HybridViewModelNumberPropertySpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelNumberPropertySpec_cxx.swift
@@ -167,6 +167,25 @@ open class HybridViewModelNumberPropertySpec_cxx : HybridViewModelPropertySpec_c
   }
   
   @inline(__always)
+  public final func setValueAsync(value: Double) -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.setValueAsync(value: value)
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func addListener(onChanged: bridge.Func_void_double) -> bridge.Result_std__function_void____ {
     do {
       let __result = try self.__implementation.addListener(onChanged: { () -> (Double) -> Void in

--- a/nitrogen/generated/ios/swift/HybridViewModelStringPropertySpec.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelStringPropertySpec.swift
@@ -15,6 +15,7 @@ public protocol HybridViewModelStringPropertySpec_protocol: HybridObject, Hybrid
   // Methods
   func getValueAsync() throws -> Promise<String>
   func set(value: String) throws -> Void
+  func setValueAsync(value: String) throws -> Promise<Void>
   func addListener(onChanged: @escaping (_ value: String) -> Void) throws -> () -> Void
   func removeListeners() throws -> Void
 }

--- a/nitrogen/generated/ios/swift/HybridViewModelStringPropertySpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridViewModelStringPropertySpec_cxx.swift
@@ -167,6 +167,25 @@ open class HybridViewModelStringPropertySpec_cxx : HybridViewModelPropertySpec_c
   }
   
   @inline(__always)
+  public final func setValueAsync(value: std.string) -> bridge.Result_std__shared_ptr_Promise_void___ {
+    do {
+      let __result = try self.__implementation.setValueAsync(value: String(value))
+      let __resultCpp = { () -> bridge.std__shared_ptr_Promise_void__ in
+        let __promise = bridge.create_std__shared_ptr_Promise_void__()
+        let __promiseHolder = bridge.wrap_std__shared_ptr_Promise_void__(__promise)
+        __result
+          .then({ __result in __promiseHolder.resolve() })
+          .catch({ __error in __promiseHolder.reject(__error.toCpp()) })
+        return __promise
+      }()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_std__shared_ptr_Promise_void___(__exceptionPtr)
+    }
+  }
+  
+  @inline(__always)
   public final func addListener(onChanged: bridge.Func_void_std__string) -> bridge.Result_std__function_void____ {
     do {
       let __result = try self.__implementation.addListener(onChanged: { () -> (String) -> Void in

--- a/nitrogen/generated/shared/c++/HybridViewModelBooleanPropertySpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelBooleanPropertySpec.cpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::rive {
       prototype.registerHybridSetter("value", &HybridViewModelBooleanPropertySpec::setValue);
       prototype.registerHybridMethod("getValueAsync", &HybridViewModelBooleanPropertySpec::getValueAsync);
       prototype.registerHybridMethod("set", &HybridViewModelBooleanPropertySpec::set);
+      prototype.registerHybridMethod("setValueAsync", &HybridViewModelBooleanPropertySpec::setValueAsync);
       prototype.registerHybridMethod("addListener", &HybridViewModelBooleanPropertySpec::addListener);
       prototype.registerHybridMethod("removeListeners", &HybridViewModelBooleanPropertySpec::removeListeners);
     });

--- a/nitrogen/generated/shared/c++/HybridViewModelBooleanPropertySpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelBooleanPropertySpec.hpp
@@ -55,6 +55,7 @@ namespace margelo::nitro::rive {
       // Methods
       virtual std::shared_ptr<Promise<bool>> getValueAsync() = 0;
       virtual void set(bool value) = 0;
+      virtual std::shared_ptr<Promise<void>> setValueAsync(bool value) = 0;
       virtual std::function<void()> addListener(const std::function<void(bool /* value */)>& onChanged) = 0;
       virtual void removeListeners() = 0;
 

--- a/nitrogen/generated/shared/c++/HybridViewModelColorPropertySpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelColorPropertySpec.cpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::rive {
       prototype.registerHybridSetter("value", &HybridViewModelColorPropertySpec::setValue);
       prototype.registerHybridMethod("getValueAsync", &HybridViewModelColorPropertySpec::getValueAsync);
       prototype.registerHybridMethod("set", &HybridViewModelColorPropertySpec::set);
+      prototype.registerHybridMethod("setValueAsync", &HybridViewModelColorPropertySpec::setValueAsync);
       prototype.registerHybridMethod("addListener", &HybridViewModelColorPropertySpec::addListener);
       prototype.registerHybridMethod("removeListeners", &HybridViewModelColorPropertySpec::removeListeners);
     });

--- a/nitrogen/generated/shared/c++/HybridViewModelColorPropertySpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelColorPropertySpec.hpp
@@ -55,6 +55,7 @@ namespace margelo::nitro::rive {
       // Methods
       virtual std::shared_ptr<Promise<double>> getValueAsync() = 0;
       virtual void set(double value) = 0;
+      virtual std::shared_ptr<Promise<void>> setValueAsync(double value) = 0;
       virtual std::function<void()> addListener(const std::function<void(double /* value */)>& onChanged) = 0;
       virtual void removeListeners() = 0;
 

--- a/nitrogen/generated/shared/c++/HybridViewModelEnumPropertySpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelEnumPropertySpec.cpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::rive {
       prototype.registerHybridSetter("value", &HybridViewModelEnumPropertySpec::setValue);
       prototype.registerHybridMethod("getValueAsync", &HybridViewModelEnumPropertySpec::getValueAsync);
       prototype.registerHybridMethod("set", &HybridViewModelEnumPropertySpec::set);
+      prototype.registerHybridMethod("setValueAsync", &HybridViewModelEnumPropertySpec::setValueAsync);
       prototype.registerHybridMethod("addListener", &HybridViewModelEnumPropertySpec::addListener);
       prototype.registerHybridMethod("removeListeners", &HybridViewModelEnumPropertySpec::removeListeners);
     });

--- a/nitrogen/generated/shared/c++/HybridViewModelEnumPropertySpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelEnumPropertySpec.hpp
@@ -56,6 +56,7 @@ namespace margelo::nitro::rive {
       // Methods
       virtual std::shared_ptr<Promise<std::string>> getValueAsync() = 0;
       virtual void set(const std::string& value) = 0;
+      virtual std::shared_ptr<Promise<void>> setValueAsync(const std::string& value) = 0;
       virtual std::function<void()> addListener(const std::function<void(const std::string& /* value */)>& onChanged) = 0;
       virtual void removeListeners() = 0;
 

--- a/nitrogen/generated/shared/c++/HybridViewModelNumberPropertySpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelNumberPropertySpec.cpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::rive {
       prototype.registerHybridSetter("value", &HybridViewModelNumberPropertySpec::setValue);
       prototype.registerHybridMethod("getValueAsync", &HybridViewModelNumberPropertySpec::getValueAsync);
       prototype.registerHybridMethod("set", &HybridViewModelNumberPropertySpec::set);
+      prototype.registerHybridMethod("setValueAsync", &HybridViewModelNumberPropertySpec::setValueAsync);
       prototype.registerHybridMethod("addListener", &HybridViewModelNumberPropertySpec::addListener);
       prototype.registerHybridMethod("removeListeners", &HybridViewModelNumberPropertySpec::removeListeners);
     });

--- a/nitrogen/generated/shared/c++/HybridViewModelNumberPropertySpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelNumberPropertySpec.hpp
@@ -55,6 +55,7 @@ namespace margelo::nitro::rive {
       // Methods
       virtual std::shared_ptr<Promise<double>> getValueAsync() = 0;
       virtual void set(double value) = 0;
+      virtual std::shared_ptr<Promise<void>> setValueAsync(double value) = 0;
       virtual std::function<void()> addListener(const std::function<void(double /* value */)>& onChanged) = 0;
       virtual void removeListeners() = 0;
 

--- a/nitrogen/generated/shared/c++/HybridViewModelStringPropertySpec.cpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelStringPropertySpec.cpp
@@ -19,6 +19,7 @@ namespace margelo::nitro::rive {
       prototype.registerHybridSetter("value", &HybridViewModelStringPropertySpec::setValue);
       prototype.registerHybridMethod("getValueAsync", &HybridViewModelStringPropertySpec::getValueAsync);
       prototype.registerHybridMethod("set", &HybridViewModelStringPropertySpec::set);
+      prototype.registerHybridMethod("setValueAsync", &HybridViewModelStringPropertySpec::setValueAsync);
       prototype.registerHybridMethod("addListener", &HybridViewModelStringPropertySpec::addListener);
       prototype.registerHybridMethod("removeListeners", &HybridViewModelStringPropertySpec::removeListeners);
     });

--- a/nitrogen/generated/shared/c++/HybridViewModelStringPropertySpec.hpp
+++ b/nitrogen/generated/shared/c++/HybridViewModelStringPropertySpec.hpp
@@ -56,6 +56,7 @@ namespace margelo::nitro::rive {
       // Methods
       virtual std::shared_ptr<Promise<std::string>> getValueAsync() = 0;
       virtual void set(const std::string& value) = 0;
+      virtual std::shared_ptr<Promise<void>> setValueAsync(const std::string& value) = 0;
       virtual std::function<void()> addListener(const std::function<void(const std::string& /* value */)>& onChanged) = 0;
       virtual void removeListeners() = 0;
 

--- a/src/specs/ViewModel.nitro.ts
+++ b/src/specs/ViewModel.nitro.ts
@@ -137,6 +137,8 @@ export interface ViewModelNumberProperty
   /** Get the current value of the number property */
   getValueAsync(): Promise<number>;
   set(value: number): void;
+  /** Set the value asynchronously — awaitable, errors propagate, writes are ordered. */
+  setValueAsync(value: number): Promise<void>;
   /** Add a listener to the view model number property. Returns a function to remove the listener. */
   addListener(onChanged: (value: number) => void): () => void;
 }
@@ -149,6 +151,8 @@ export interface ViewModelStringProperty
   /** Get the current value of the string property */
   getValueAsync(): Promise<string>;
   set(value: string): void;
+  /** Set the value asynchronously — awaitable, errors propagate, writes are ordered. */
+  setValueAsync(value: string): Promise<void>;
   /** Add a listener to the view model string property. Returns a function to remove the listener. */
   addListener(onChanged: (value: string) => void): () => void;
 }
@@ -161,6 +165,8 @@ export interface ViewModelBooleanProperty
   /** Get the current value of the boolean property */
   getValueAsync(): Promise<boolean>;
   set(value: boolean): void;
+  /** Set the value asynchronously — awaitable, errors propagate, writes are ordered. */
+  setValueAsync(value: boolean): Promise<void>;
   /** Add a listener to the view model boolean property. Returns a function to remove the listener. */
   addListener(onChanged: (value: boolean) => void): () => void;
 }
@@ -173,6 +179,8 @@ export interface ViewModelColorProperty
   /** Get the current value of the color property */
   getValueAsync(): Promise<number>;
   set(value: number): void;
+  /** Set the value asynchronously — awaitable, errors propagate, writes are ordered. */
+  setValueAsync(value: number): Promise<void>;
   /** Add a listener to the view model color property. Returns a function to remove the listener. */
   addListener(onChanged: (value: number) => void): () => void;
 }
@@ -185,6 +193,8 @@ export interface ViewModelEnumProperty
   /** Get the current value of the enum property */
   getValueAsync(): Promise<string>;
   set(value: string): void;
+  /** Set the value asynchronously — awaitable, errors propagate, writes are ordered. */
+  setValueAsync(value: string): Promise<void>;
   /** Add a listener to the view model enum property. Returns a function to remove the listener. */
   addListener(onChanged: (value: string) => void): () => void;
 }


### PR DESCRIPTION
Stacked on #289.

Adds `setValueAsync(value)` to Number, String, Boolean, Color, and Enum property types across all 4 backends (iOS experimental, iOS legacy, Android experimental, Android legacy).

On iOS experimental, this is a proper async write — the promise resolves only after the SDK `setValue` call completes on the main actor, giving ordering guarantees and error propagation. On legacy and Android, `set()` is already synchronous so `setValueAsync` is a thin wrapper that makes the API consistent.

Includes harness tests covering all 5 property types.