### PR TITLE
ci(ios): pin iOS jobs to macos-15 to stabilize simulator boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,9 @@ jobs:
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
-    runs-on: macos-latest
+    # Pinned: macos-latest is mid-migration to macOS 26, whose simulator set
+    # has no iPhone 16 Pro on an iOS >=26 runtime, breaking the harness boot.
+    runs-on: macos-15
     env:
       XCODE_VERSION: 26.3
       TURBO_CACHE_DIR: .turbo/ios
@@ -208,7 +210,9 @@ jobs:
           yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   test-harness-ios:
-    runs-on: macos-latest
+    # Pinned to macos-15 — see build-ios. macos-26 runners lack a matching
+    # iPhone 16 Pro / iOS >=26 simulator, so the boot step fails intermittently.
+    runs-on: macos-15
     timeout-minutes: 60
     env:
       XCODE_VERSION: 26.3


### PR DESCRIPTION
`macos-latest` is mid-migration to macOS 26, so the iOS jobs randomly land on `macos-15-arm64` or `macos-26-arm64`. Only the macOS 15 image has a pre-created **iPhone 16 Pro on an iOS >=26 runtime**; on macos-26 the `simulator-action` boot step fails with *"No devices found"*.

This is why an identical commit passes on one run and fails on another — e.g. the 0.4.12 release PR (#299) failed solely because it drew a macos-26 runner, while the same code on `main` passed on macos-15.

Pin `build-ios` and `test-harness-ios` to `macos-15` for deterministic runs.

Follow-up (not in this PR): make the simulator selection image-agnostic (query an available iOS runtime / device dynamically) so the eventual macOS 15 retirement doesn't reintroduce this.