### PR TITLE
fix(ios): build fmt pod as C++17 to fix Xcode 26.4+ consteval error

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -33,5 +33,20 @@ target 'RiveExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # fmt `consteval` build error on Xcode 26.4+ (Apple clang 21): fmt's compile-time
+    # FMT_STRING (basic_format_string's consteval ctor) is rejected as a non-constant
+    # expression. Compile only the `fmt` pod as C++17 so fmt's own base.h disables consteval:
+    # with FMT_CPLUSPLUS < 201709 it hits `#define FMT_USE_CONSTEVAL 0` before the
+    # `__cpp_consteval` branch. NOTE: a plain `-DFMT_USE_CONSTEVAL=0` define does NOT work —
+    # base.h re-#defines FMT_USE_CONSTEVAL unconditionally (it is not #ifndef-guarded), so it
+    # overrides any command-line define. Verified on Xcode 26.6. Real fix is upstream in
+    # React Native 0.83+ (fmtlib/fmt#4740, facebook/react-native#55601); remove once we bump.
+    installer.pods_project.targets.each do |target|
+      next unless target.name == 'fmt'
+      target.build_configurations.each do |bc|
+        bc.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

Apple clang 21 (Xcode 26.4+) rejects fmt's compile-time `FMT_STRING`/`consteval` as a non-constant-expression, so the iOS build fails compiling fmt's `format.cc`:

```
call to consteval function 'fmt::basic_format_string<...>' is not a constant expression
```

React Native vendors fmt (`RCT-Folly` → `fmt 11.0.2` on our RN 0.80.3). CI doesn't hit it (Xcode 26.3); local builds on 26.4+/26.5 do. Tracked in [facebook/react-native#55601](https://github.com/facebook/react-native/issues/55601) and [fmtlib/fmt#4740](https://github.com/fmtlib/fmt/issues/4740).

## Fix

Compile **only the `fmt` pod as C++17** via a `Podfile` `post_install` build setting. Under C++17 fmt's `consteval` path is disabled (`__cpp_consteval` absent), which sidesteps the error. Scoped to `target.name == 'fmt'` so the rest of the graph keeps C++20. No vendored-header edits and robust across fmt versions.

## How others handle it

- **React Native ≥ 0.83** — fixed upstream (the real solution).
- **Expo (interim)** — a config plugin that patches `fmt/base.h` (`FMT_USE_CONSTEVAL → 0`), per [expo/expo#44229](https://github.com/expo/expo/issues/44229).
- **RN community** — the `fmt`-as-C++17 build setting used here.

All interim options disable fmt's consteval path; this is the bare-RN one.

## Longevity

This is only needed because we're on RN 0.80.3. **Remove this block once we bump to RN 0.83+**, which carries the upstream fix (also noted in the Podfile comment).

## Verify

`pod install`, then build the iOS example on Xcode 26.4+ — the `fmt` target compiles clean.