### PR TITLE
fix(android): bump rive-android to 11.6.1 (fixes data-binding UAF crash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
   "runtimeVersions": {
     "ios": "6.20.4",
-    "android": "11.4.1"
+    "android": "11.6.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Bumps `runtimeVersions.android` 11.4.1 → 11.6.1 on the experimental backend line to fix the intermittent native `SIGSEGV` in `test-harness-android`.

Root cause is a single-threaded re-entrancy / iterator-invalidation **use-after-free** in `rive::DataBindContainer::updateDataBinds` (a bind that auto-binds a nested view model re-enters `addDataBind`/`removeDataBind` and invalidates the active iterator). Fixed upstream in rive-runtime [#12649](https://github.com/rive-app/rive-runtime/pull/12649), shipped in rive-android 11.6.1 (11.4.1/11.5.0/11.6.0 are vulnerable). The experimental backend compiles + builds clean against 11.6.1 (no API changes needed).

Full investigation: #308. (`main` is unaffected — it already pins 11.6.1 and does not carry the experimental backend.)