### PR TITLE
fix(ios): use C++17 for fmt pod (FMT_USE_CONSTEVAL=0 from #314 does not build)

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -34,21 +34,18 @@ target 'RiveExample' do
       # :ccache_enabled => true
     )
 
-    # fmt `consteval` build error on Xcode 26.4+ (Apple clang 21): the compiler rejects
-    # fmt's compile-time FMT_STRING (basic_format_string's consteval ctor) as a
-    # non-constant-expression. Disable fmt's consteval path via FMT_USE_CONSTEVAL=0 while
-    # keeping C++20 — this is the interim workaround Expo recommends (expo/expo#44229) and
-    # mirrors what fmt itself does for broken-consteval compilers (fmt/base.h sets
-    # FMT_USE_CONSTEVAL 0 for e.g. Apple clang < 14). Preferred over compiling the fmt pod as
-    # C++17 because it keeps the whole graph on a single C++ standard. Real fix is upstream in
+    # fmt `consteval` build error on Xcode 26.4+ (Apple clang 21): fmt's compile-time
+    # FMT_STRING (basic_format_string's consteval ctor) is rejected as a non-constant
+    # expression. Compile only the `fmt` pod as C++17 so fmt's own base.h disables consteval:
+    # with FMT_CPLUSPLUS < 201709 it hits `#define FMT_USE_CONSTEVAL 0` before the
+    # `__cpp_consteval` branch. NOTE: a plain `-DFMT_USE_CONSTEVAL=0` define does NOT work —
+    # base.h re-#defines FMT_USE_CONSTEVAL unconditionally (it is not #ifndef-guarded), so it
+    # overrides any command-line define. Verified on Xcode 26.6. Real fix is upstream in
     # React Native 0.83+ (fmtlib/fmt#4740, facebook/react-native#55601); remove once we bump.
     installer.pods_project.targets.each do |target|
       next unless target.name == 'fmt'
       target.build_configurations.each do |bc|
-        defs = bc.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
-        defs = [defs] unless defs.is_a?(Array)
-        defs << 'FMT_USE_CONSTEVAL=0' unless defs.include?('FMT_USE_CONSTEVAL=0')
-        bc.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = defs
+        bc.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
       end
     end
   end


### PR DESCRIPTION
Follow-up to #314. The merged fmt workaround (define `FMT_USE_CONSTEVAL=0`) **does not actually fix** the Xcode 26.4+ (Apple clang 21) consteval error: `fmt/base.h` re-`#define`s `FMT_USE_CONSTEVAL` unconditionally (it is not `#ifndef`-guarded), so it overrides the command-line define and the build still fails. Verified failing on Xcode 26.6.

Switches to compiling the `fmt` pod as **C++17**, which makes fmt's own `base.h` disable consteval (`FMT_CPLUSPLUS < 201709` → `FMT_USE_CONSTEVAL 0`). **Verified building on Xcode 26.6.** CI (Xcode 26.3) does not hit the consteval error, so this only affects local builds on 26.4+.

Same approach as #306 (the main-line fmt PR). Real fix is upstream in React Native 0.83+.