### PR TITLE
fix(hooks): warn and no-op when a property setter is called after dispose

### DIFF
--- a/example/src/__tests__/staleSetterWrite.test.tsx
+++ b/example/src/__tests__/staleSetterWrite.test.tsx
@@ -1,0 +1,78 @@
+import { it, expect, render, waitFor, cleanup } from 'react-native-harness';
+import { useEffect } from 'react';
+import { View } from 'react-native';
+import {
+  Fit,
+  RiveView,
+  RiveFileFactory,
+  useRiveNumber,
+  useViewModelInstance,
+  type RiveFile,
+  type ViewModelInstance,
+} from '@rive-app/react-native';
+
+/**
+ * A `useRive*` setter captured in a stale closure (async callback / timeout)
+ * fires after the component unmounted. By then the property was disposed, so
+ * an unguarded write throws "Cannot set hybrid property ... `NativeState` is
+ * `null`" — fatal when uncaught in release. The liveRef guard in
+ * useRiveProperty must turn it into a no-op.
+ */
+const DATABINDING = require('../../assets/rive/databinding.riv');
+const WRITES = 400;
+
+type Ctx = {
+  setValue: ((v: number) => void) | null;
+};
+
+function AgeHook({ instance, ctx }: { instance: ViewModelInstance; ctx: Ctx }) {
+  const { setValue } = useRiveNumber('age', instance);
+  useEffect(() => {
+    ctx.setValue = setValue;
+  }, [ctx, setValue]);
+  return null;
+}
+
+function Repro({ file, ctx }: { file: RiveFile; ctx: Ctx }) {
+  const { instance } = useViewModelInstance(file);
+  if (!instance) return null;
+  return (
+    <View style={{ width: 200, height: 200 }}>
+      <RiveView
+        style={{ flex: 1 }}
+        file={file}
+        autoPlay={true}
+        dataBind={instance}
+        fit={Fit.Contain}
+      />
+      <AgeHook instance={instance} ctx={ctx} />
+    </View>
+  );
+}
+
+it('stale setter write after unmount is a safe no-op', async () => {
+  const file = await RiveFileFactory.fromSource(DATABINDING, undefined);
+  const ctx: Ctx = { setValue: null };
+
+  await render(<Repro file={file} ctx={ctx} />);
+  await waitFor(() => expect(ctx.setValue).toBeTruthy());
+
+  const staleSetter = ctx.setValue!;
+
+  // Unmount: useDisposableMemo disposes the property + VMI (deferred via
+  // setTimeout(0) in __DEV__), RiveView tears down.
+  cleanup();
+  await new Promise((r) => setTimeout(r, 100));
+
+  // The stale closure fires — repeatedly, with yields, to also give any
+  // cross-thread teardown a chance to interleave.
+  for (let i = 0; i < WRITES; i++) {
+    staleSetter(i % 100);
+    if (i % 25 === 0) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+  }
+  await new Promise((r) => setTimeout(r, 200));
+
+  expect(true).toBe(true);
+});

--- a/example/src/__tests__/staleSetterWrite.test.tsx
+++ b/example/src/__tests__/staleSetterWrite.test.tsx
@@ -19,7 +19,7 @@ import {
  * useRiveProperty must turn it into a no-op.
  */
 const DATABINDING = require('../../assets/rive/databinding.riv');
-const WRITES = 400;
+const WRITES = 50;
 
 type Ctx = {
   setValue: ((v: number) => void) | null;

--- a/src/hooks/__tests__/useRiveProperty.test.ts
+++ b/src/hooks/__tests__/useRiveProperty.test.ts
@@ -3,6 +3,14 @@ import { useRiveProperty } from '../useRiveProperty';
 import type { ViewModelInstance } from '../../specs/ViewModel.nitro';
 
 describe('useRiveProperty', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (console.warn as jest.Mock).mockRestore();
+  });
+
   const createMockProperty = (initialValue: string) => {
     let currentValue = initialValue;
     let listener: ((value: string) => void) | null = null;
@@ -292,7 +300,7 @@ describe('useRiveProperty', () => {
       };
     };
 
-    it('setter captured before a path change does not write to the disposed property', () => {
+    it('setter captured before a path change writes to the current property, not the disposed one', () => {
       const oldProperty = createDisposeTrackingProperty('old');
       const newProperty = createDisposeTrackingProperty('new');
       const mockInstance = createMockViewModelInstance({
@@ -320,7 +328,10 @@ describe('useRiveProperty', () => {
         staleSetter('boom');
       });
 
+      // Live-ref semantics (same as useRiveTrigger): the setter targets the
+      // hook's current property, never the disposed one.
       expect(oldProperty.writesAfterDispose).toEqual([]);
+      expect(newProperty.value).toBe('boom');
     });
 
     it('setter called after unmount does not write to the disposed property', () => {
@@ -349,6 +360,9 @@ describe('useRiveProperty', () => {
         staleSetter('boom');
 
         expect(property.writesAfterDispose).toEqual([]);
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringContaining("setValue('text') called after dispose")
+        );
       } finally {
         jest.useRealTimers();
       }

--- a/src/hooks/__tests__/useRiveProperty.test.ts
+++ b/src/hooks/__tests__/useRiveProperty.test.ts
@@ -252,4 +252,106 @@ describe('useRiveProperty', () => {
 
     expect(result.current[0]).toBe('Instance2Value');
   });
+
+  // A setter captured in a stale closure (e.g. an async callback) can fire
+  // after its property was disposed by a deps change or unmount. The write
+  // must be a no-op: on a disposed native property it throws
+  // ("NativeState is null"), which is fatal when uncaught in release.
+  describe('stale-closure writes', () => {
+    const createDisposeTrackingProperty = (initialValue: string) => {
+      let currentValue = initialValue;
+      let listener: ((value: string) => void) | null = null;
+      const writesAfterDispose: string[] = [];
+      let disposed = false;
+
+      return {
+        get value() {
+          return currentValue;
+        },
+        set value(newValue: string) {
+          if (disposed) {
+            writesAfterDispose.push(newValue);
+            return;
+          }
+          currentValue = newValue;
+          listener?.(newValue);
+        },
+        addListener: jest.fn((callback: (value: string) => void) => {
+          listener = callback;
+          callback(currentValue);
+          return () => {
+            listener = null;
+          };
+        }),
+        dispose: jest.fn(() => {
+          disposed = true;
+        }),
+        get writesAfterDispose() {
+          return writesAfterDispose;
+        },
+      };
+    };
+
+    it('setter captured before a path change does not write to the disposed property', () => {
+      const oldProperty = createDisposeTrackingProperty('old');
+      const newProperty = createDisposeTrackingProperty('new');
+      const mockInstance = createMockViewModelInstance({
+        'drinks/tea': oldProperty,
+        'drinks/coffee': newProperty,
+      } as unknown as Record<string, ReturnType<typeof createMockProperty>>);
+
+      const { result, rerender } = renderHook(
+        (props: { path: string }) =>
+          useRiveProperty<any, string>(
+            mockInstance,
+            props.path,
+            (vmi: any, p) => vmi.stringProperty(p)
+          ),
+        { initialProps: { path: 'drinks/tea' } }
+      );
+
+      const staleSetter = result.current[1];
+
+      // Deps change → useDisposableMemo disposes oldProperty during render
+      rerender({ path: 'drinks/coffee' });
+      expect(oldProperty.dispose).toHaveBeenCalled();
+
+      act(() => {
+        staleSetter('boom');
+      });
+
+      expect(oldProperty.writesAfterDispose).toEqual([]);
+    });
+
+    it('setter called after unmount does not write to the disposed property', () => {
+      jest.useFakeTimers();
+      try {
+        const property = createDisposeTrackingProperty('initial');
+        const mockInstance = createMockViewModelInstance({
+          text: property,
+        } as unknown as Record<string, ReturnType<typeof createMockProperty>>);
+
+        const { result, unmount } = renderHook(() =>
+          useRiveProperty<any, string>(mockInstance, 'text', (vmi: any, p) =>
+            vmi.stringProperty(p)
+          )
+        );
+
+        const staleSetter = result.current[1];
+
+        unmount();
+        // In __DEV__, useDisposableMemo defers unmount disposal via setTimeout(0)
+        act(() => {
+          jest.runAllTimers();
+        });
+        expect(property.dispose).toHaveBeenCalled();
+
+        staleSetter('boom');
+
+        expect(property.writesAfterDispose).toEqual([]);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
 });

--- a/src/hooks/useRiveProperty.ts
+++ b/src/hooks/useRiveProperty.ts
@@ -34,6 +34,7 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
   // Nulled by useDisposableMemo the moment the property is disposed, so the
   // setter can tell a live property from a disposed one (see setPropertyValue).
   const liveRef = useRef<ObservableViewModelProperty<T> | undefined>(undefined);
+  const wasEverLive = useRef(false);
   const property = useDisposableMemo(
     () => {
       if (!viewModelInstance) return undefined;
@@ -46,6 +47,10 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
     [viewModelInstance, path],
     liveRef
   );
+
+  if (liveRef.current) {
+    wasEverLive.current = true;
+  }
 
   // Always start undefined — the listener delivers the current value as its first emission.
   // (iOS experimental: via valueStream; iOS/Android legacy: emitted synchronously on subscribe)
@@ -91,9 +96,10 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
     };
   }, [property]);
 
-  // Set the value of the property (no-op if property isn't available yet).
-  // Uses tracked `value` from state for updater functions — avoids a synchronous
-  // property.value read and is consistent with how React state works.
+  // Set the value of the property (warn + no-op if the property isn't
+  // available). Uses tracked `value` from state for updater functions —
+  // avoids a synchronous property.value read and is consistent with how
+  // React state works.
   const setPropertyValue = useCallback(
     (valueOrUpdater: T | ((prevValue: T | undefined) => T)) => {
       // Read through liveRef instead of the captured `property`: a stale
@@ -103,6 +109,18 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
       // release). Same guard as useRiveTrigger.
       const liveProperty = liveRef.current;
       if (!liveProperty) {
+        if (wasEverLive.current) {
+          console.warn(
+            `useRiveProperty: setValue('${path}') called after dispose. ` +
+              'The property has been cleaned up — this is likely a stale closure ' +
+              'from an async callback that fired after unmount.'
+          );
+        } else {
+          console.warn(
+            `useRiveProperty: setValue('${path}') called but the property is not available yet. ` +
+              'The viewModelInstance may still be loading.'
+          );
+        }
         return;
       } else {
         const newValue =
@@ -116,7 +134,7 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
     // property — consumers' effects keyed on the setter re-fire (see
     // "should apply value after instance becomes available" test).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [property, value]
+    [property, path, value]
   );
 
   return [value, setPropertyValue, error, property as unknown as P];
@@ -129,8 +147,7 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
  * @template T - The primitive type of the property value (number, boolean, string)
  */
 interface ObservableViewModelProperty<T>
-  extends ViewModelProperty,
-    ObservableProperty {
+  extends ViewModelProperty, ObservableProperty {
   addListener: (onChanged: (value: T) => void) => () => void;
   value: T;
 }

--- a/src/hooks/useRiveProperty.ts
+++ b/src/hooks/useRiveProperty.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type ObservableProperty,
   type ViewModelInstance,
@@ -31,6 +31,9 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
   Error | null,
   P | undefined,
 ] {
+  // Nulled by useDisposableMemo the moment the property is disposed, so the
+  // setter can tell a live property from a disposed one (see setPropertyValue).
+  const liveRef = useRef<ObservableViewModelProperty<T> | undefined>(undefined);
   const property = useDisposableMemo(
     () => {
       if (!viewModelInstance) return undefined;
@@ -40,7 +43,8 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
       ) as unknown as ObservableViewModelProperty<T>;
     },
     (p) => p?.dispose(),
-    [viewModelInstance, path]
+    [viewModelInstance, path],
+    liveRef
   );
 
   // Always start undefined — the listener delivers the current value as its first emission.
@@ -92,16 +96,26 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
   // property.value read and is consistent with how React state works.
   const setPropertyValue = useCallback(
     (valueOrUpdater: T | ((prevValue: T | undefined) => T)) => {
-      if (!property) {
+      // Read through liveRef instead of the captured `property`: a stale
+      // closure (e.g. an async callback) can fire after the property was
+      // disposed by a deps change or unmount, and writing to the disposed
+      // hybrid throws ("NativeState is null" — fatal when uncaught in
+      // release). Same guard as useRiveTrigger.
+      const liveProperty = liveRef.current;
+      if (!liveProperty) {
         return;
       } else {
         const newValue =
           typeof valueOrUpdater === 'function'
             ? (valueOrUpdater as (prevValue: T | undefined) => T)(value)
             : valueOrUpdater;
-        property.value = newValue;
+        liveProperty.value = newValue;
       }
     },
+    // `property` kept in deps so the setter identity changes with the
+    // property — consumers' effects keyed on the setter re-fire (see
+    // "should apply value after instance becomes available" test).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [property, value]
   );
 
@@ -115,7 +129,8 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
  * @template T - The primitive type of the property value (number, boolean, string)
  */
 interface ObservableViewModelProperty<T>
-  extends ViewModelProperty, ObservableProperty {
+  extends ViewModelProperty,
+    ObservableProperty {
   addListener: (onChanged: (value: T) => void) => () => void;
   value: T;
 }


### PR DESCRIPTION
A setter returned by `useRiveNumber`/`useRiveString`/etc. can be captured in a stale closure (async callback, timeout) and fire after its property was disposed by a deps change or unmount. The write then reaches the disposed hybrid and throws `Cannot set hybrid property ... NativeState is null` — fatal when uncaught in a release app.

The fix routes writes through the `liveRef` that `useDisposableMemo` already maintains (nulled at dispose time) — the same guard `useRiveTrigger` uses. A write after unmount warns and no-ops (with the path and likely cause) instead of throwing; a write captured before a deps change targets the hook's current property, matching `useRiveTrigger` semantics. `property` stays in the `useCallback` deps so the setter identity still changes with the property.

Tests: jest cases for the after-unmount no-op+warn and the deps-change redirect, plus an on-device harness test (`staleSetterWrite.test.tsx`) that fails on the unguarded hook — verified on the Android emulator on both backends.