### PR TITLE
fix(android): bump rive-android to 11.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
   "runtimeVersions": {
     "ios": "6.20.4",
-    "android": "11.6.1"
+    "android": "11.6.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Bumps the pinned Android runtime from 11.6.1 to 11.6.2, which backports the ViewModelInstance read/write lock from 11.7.0. A patch bump carries just the lock; the 11.7 minor also ships the new Vulkan backend (opt-in — OpenGL stays the default renderer) plus other changes, and grows `librive-android.so` by ~2 MB per ABI (arm64: 5.76 → 7.73 MB uncompressed, +34%) since Vulkan is compiled into the prebuilt library even when unused.

In 11.6.1, `StateMachineInstance.advance()` holds the file lock but ViewModelInstance property access takes no lock, so a property write or instance teardown on another thread can race the advance path's `DataBindContainer::updateDataBinds` and crash (SIGSEGV reported in production on 0.4.11). Related ledger: #308.

Verified on a Pixel 6 API 34 emulator (arm64 debug build): the databinding-related harness suites and a targeted advance-vs-write stress loop are green on both 11.6.1 and 11.6.2 (the race did not reproduce locally at this volume; no regressions from the bump).