### PR TITLE
fix: bump rive-android to 11.7.2 and rive-ios to 6.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
   "runtimeVersions": {
-    "ios": "6.20.4",
-    "android": "11.6.2"
+    "ios": "6.21.1",
+    "android": "11.7.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Bumps the pinned native runtimes to the latest releases: rive-android 11.6.2 → 11.7.2 and rive-ios 6.20.4 → 6.21.1.

On Android, 11.7.x adds a Vulkan render backend, but it is opt-in (`RenderBackend.OpenGL` is the default) and only exists in the new command-queue API — the legacy `RiveAnimationView` path this library uses stays on OpenGL, so no renderer change for us. 11.7.x also carries the full ViewModelInstance read/write lock (11.6.2 had the backport) plus serialized touch-triggered advances and mipmap generation fixes; 11.7.2 additionally locks VMI mutation APIs and fixes trigger dirtying.

On iOS, 6.21.x adds VoiceOver semantics support, artboard volume control, and defaults `RiveUIView.isOpaque` to false so transparent backgrounds render correctly; 6.21.1 additionally fixes the Lua `Data` global regression and draws the first frame synchronously when resuming from pause for faster time-to-first-frame.
