### PR TITLE
fix: bump old runtime pins to rive-android 11.7.1 and rive-ios 6.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
   "runtimeVersions": {
-    "ios": "6.20.4",
-    "android": "11.6.2"
+    "ios": "6.21.0",
+    "android": "11.7.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Bumps the old runtime pins in package.json to match the latest native runtimes.

- rive-android: 11.6.2 -> 11.7.1
- rive-ios: 6.20.4 -> 6.21.0