### PR TITLE
fix(android): port VMI dispose and Handler fixes to the legacy backend

### DIFF
--- a/android/src/legacy/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/legacy/java/com/rive/RiveReactNativeView.kt
@@ -110,6 +110,9 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
     if (willDispose) {
       riveAnimationView?.dispose()
       removeEventListeners()
+      // Post-dispose reads must resolve null, not the retained (released)
+      // instance; also stops pinning it for the view's remaining lifetime.
+      lastKnownViewModelInstance = null
     }
     super.onDetachedFromWindow()
   }
@@ -182,6 +185,10 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
   private var lastKnownViewModelInstance: ViewModelInstance? = null
 
   private fun readViewModelInstanceOnMain(): ViewModelInstance? {
+    // A refresh posted before dispose() can run after it; reading the
+    // torn-down controller's stale list here would re-cache a released
+    // instance right after onDetachedFromWindow cleared it.
+    if (willDispose) return null
     val stateMachines = riveAnimationView?.controller?.stateMachines
     return if (!stateMachines.isNullOrEmpty()) {
       stateMachines.first().viewModelInstance

--- a/android/src/legacy/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/legacy/java/com/rive/RiveReactNativeView.kt
@@ -184,6 +184,8 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
   @Volatile
   private var lastKnownViewModelInstance: ViewModelInstance? = null
 
+  private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
+
   private fun readViewModelInstanceOnMain(): ViewModelInstance? {
     // A refresh posted before dispose() can run after it; reading the
     // torn-down controller's stale list here would re-cache a released
@@ -202,7 +204,7 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
       lastKnownViewModelInstance = readViewModelInstanceOnMain()
       return lastKnownViewModelInstance
     }
-    android.os.Handler(android.os.Looper.getMainLooper()).post {
+    mainHandler.post {
       lastKnownViewModelInstance = readViewModelInstanceOnMain()
     }
     return lastKnownViewModelInstance


### PR DESCRIPTION
Ports 6e55131 and 84e6d26 from PR #331 (android/src/main) to the legacy copy of RiveReactNativeView.kt: clear the `lastKnownViewModelInstance` snapshot on the disposing detach and resolve null from the main-thread read once `willDispose` is set, so post-dispose reads return null instead of a released instance; and reuse a cached main-thread Handler instead of allocating one per off-main `getViewModelInstance()` call. The file is now byte-identical to main's fixed copy.