### PR TITLE
ci(ios): trial Cirrus Runners (macos-runner:tahoe) for the iOS jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,21 +275,19 @@ jobs:
           path: example/ios/build
           key: ${{ steps.ios-build-cache.outputs.cache-primary-key }}
 
-      # The Cirrus image has no pre-created devices, and simulator-action only
-      # matches existing ones — create the device (and runtime, if missing) first.
-      - name: Ensure iPhone 16 Pro simulator exists
+      # The Cirrus image only pre-creates devices for its oldest runtime (iOS 18),
+      # and simulator-action doesn't create devices — make one on iOS 26 explicitly.
+      - name: Create iPhone 16 Pro simulator on iOS 26
         run: |
-          xcrun simctl list runtimes
-          if ! xcrun simctl list devices available | grep -q 'iPhone 16 Pro ('; then
+          runtime=$(xcrun simctl list runtimes available | awk '/^iOS 26/{id=$NF} END{print id}')
+          if [ -z "$runtime" ]; then
+            echo "No iOS 26 runtime installed; downloading via xcodebuild"
+            sudo xcodebuild -downloadPlatform iOS
             runtime=$(xcrun simctl list runtimes available | awk '/^iOS 26/{id=$NF} END{print id}')
-            if [ -z "$runtime" ]; then
-              echo "No iOS 26 runtime installed; downloading via xcodebuild"
-              sudo xcodebuild -downloadPlatform iOS
-              runtime=$(xcrun simctl list runtimes available | awk '/^iOS 26/{id=$NF} END{print id}')
-            fi
-            echo "Creating iPhone 16 Pro on $runtime"
-            xcrun simctl create 'iPhone 16 Pro' com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro "$runtime"
           fi
+          echo "Creating iPhone 16 Pro on $runtime"
+          xcrun simctl create 'iPhone 16 Pro' com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro "$runtime"
+          xcrun simctl list devices available
 
       - name: Boot iOS Simulator
         uses: futureware-tech/simulator-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,11 +144,12 @@ jobs:
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
-    # Pinned: macos-latest is mid-migration to macOS 26, whose simulator set
-    # has no iPhone 16 Pro on an iOS >=26 runtime, breaking the harness boot.
-    runs-on: macos-15
+    # Trial: Cirrus Runners' macOS 26 (Tahoe) image on Apple Silicon. The
+    # runner image ships the 3 latest Xcodes (26.0.1/26.1.1/26.2) plus the
+    # `xcodes` switcher, so XCODE_VERSION must be one of those.
+    runs-on: ghcr.io/cirruslabs/macos-runner:tahoe
     env:
-      XCODE_VERSION: 26.3
+      XCODE_VERSION: 26.2
       TURBO_CACHE_DIR: .turbo/ios
     steps:
       - name: Checkout
@@ -174,11 +175,9 @@ jobs:
             echo "turbo_cache_hit=1" >> $GITHUB_ENV
           fi
 
-      - name: Use appropriate Xcode version
+      - name: Select Xcode version
         if: env.turbo_cache_hit != 1
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ env.XCODE_VERSION }}
+        run: sudo xcodes select ${{ env.XCODE_VERSION }}
 
       - name: Restore cocoapods
         if: env.turbo_cache_hit != 1
@@ -214,12 +213,11 @@ jobs:
           yarn turbo run build:ios --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   test-harness-ios:
-    # Pinned to macos-15 — see build-ios. macos-26 runners lack a matching
-    # iPhone 16 Pro / iOS >=26 simulator, so the boot step fails intermittently.
-    runs-on: macos-15
+    # Trial: Cirrus Runners — see build-ios.
+    runs-on: ghcr.io/cirruslabs/macos-runner:tahoe
     timeout-minutes: 60
     env:
-      XCODE_VERSION: 26.3
+      XCODE_VERSION: 26.2
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -227,10 +225,8 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Use appropriate Xcode version
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ env.XCODE_VERSION }}
+      - name: Select Xcode version
+        run: sudo xcodes select ${{ env.XCODE_VERSION }}
 
       - name: Restore cocoapods
         id: cocoapods-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,22 @@ jobs:
           path: example/ios/build
           key: ${{ steps.ios-build-cache.outputs.cache-primary-key }}
 
+      # The Cirrus image has no pre-created devices, and simulator-action only
+      # matches existing ones — create the device (and runtime, if missing) first.
+      - name: Ensure iPhone 16 Pro simulator exists
+        run: |
+          xcrun simctl list runtimes
+          if ! xcrun simctl list devices available | grep -q 'iPhone 16 Pro ('; then
+            runtime=$(xcrun simctl list runtimes available | awk '/^iOS 26/{id=$NF} END{print id}')
+            if [ -z "$runtime" ]; then
+              echo "No iOS 26 runtime installed; downloading via xcodebuild"
+              sudo xcodebuild -downloadPlatform iOS
+              runtime=$(xcrun simctl list runtimes available | awk '/^iOS 26/{id=$NF} END{print id}')
+            fi
+            echo "Creating iPhone 16 Pro on $runtime"
+            xcrun simctl create 'iPhone 16 Pro' com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro "$runtime"
+          fi
+
       - name: Boot iOS Simulator
         uses: futureware-tech/simulator-action@v4
         with:


### PR DESCRIPTION
Retries #122 on top of today's CI: moves `build-ios` and `test-harness-ios` from the pinned `macos-15` GitHub runners to Cirrus Runners' `ghcr.io/cirruslabs/macos-runner:tahoe` image (Apple Silicon, macOS 26). The image ships the 3 latest Xcodes (26.0.1/26.1.1/26.2) with the `xcodes` switcher, so `XCODE_VERSION` drops from 26.3 to 26.2 and the `setup-xcode` action is replaced with `sudo xcodes select`.

Goal is to compare speed and simulator-boot reliability against the macos-15 pin (see the pin rationale in #300). Note: jobs will sit queued unless the Cirrus Runners GitHub App is installed and active on the org — if it isn't, that's the first thing to check.