### PR TITLE
ci(android): collect real crash evidence when harness jobs fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,13 +599,15 @@ jobs:
           script: |
             adb install expo57-example/android/app/build/outputs/apk/debug/app-debug.apk
             sleep 10
-            cd expo57-example && for attempt in 1 2 3; do echo "Attempt $attempt of 3"; if timeout 600 env ANDROID_AVD=test yarn test:harness:android --verbose --testTimeout 120000; then echo "Tests passed on attempt $attempt"; exit 0; fi; echo "Attempt $attempt failed (exit $?), retrying..."; sleep 5; done; echo "All attempts failed"; exit 1
+            cd expo57-example && for attempt in 1 2 3; do echo "Attempt $attempt of 3"; if timeout 600 env ANDROID_AVD=test yarn test:harness:android --verbose --testTimeout 120000; then echo "Tests passed on attempt $attempt"; exit 0; fi; echo "Attempt $attempt failed (exit $?), retrying..."; ../scripts/collect-android-crash-logs.sh "$attempt" ../crash-logs; sleep 5; done; ../scripts/collect-android-crash-logs.sh final ../crash-logs; echo "All attempts failed"; exit 1
 
-      - name: Debug - Check logcat
+      - name: Upload Android crash logs
         if: failure() || cancelled()
-        run: |
-          echo "=== Checking logcat for errors ==="
-          adb logcat -d -s ReactNativeJS:* RNRive:* | tail -200 || echo "No logs found"
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-harness-crash-logs
+          path: crash-logs/
+          if-no-files-found: ignore
 
   test-harness-ios-legacy:
     # Same as test-harness-ios but with the legacy Rive backend
@@ -940,10 +942,12 @@ jobs:
           script: |
             adb install expo57-example/android/app/build/outputs/apk/debug/app-debug.apk
             sleep 10
-            cd expo57-example && for attempt in 1 2 3; do echo "Attempt $attempt of 3"; if timeout 600 env ANDROID_AVD=test yarn test:harness:android --verbose --testTimeout 120000; then echo "Tests passed on attempt $attempt"; exit 0; fi; echo "Attempt $attempt failed (exit $?), retrying..."; sleep 5; done; echo "All attempts failed"; exit 1
+            cd expo57-example && for attempt in 1 2 3; do echo "Attempt $attempt of 3"; if timeout 600 env ANDROID_AVD=test yarn test:harness:android --verbose --testTimeout 120000; then echo "Tests passed on attempt $attempt"; exit 0; fi; echo "Attempt $attempt failed (exit $?), retrying..."; ../scripts/collect-android-crash-logs.sh "$attempt" ../crash-logs; sleep 5; done; ../scripts/collect-android-crash-logs.sh final ../crash-logs; echo "All attempts failed"; exit 1
 
-      - name: Debug - Check logcat
+      - name: Upload Android crash logs
         if: failure() || cancelled()
-        run: |
-          echo "=== Checking logcat for errors ==="
-          adb logcat -d -s ReactNativeJS:* RNRive:* | tail -200 || echo "No logs found"
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-harness-legacy-crash-logs
+          path: crash-logs/
+          if-no-files-found: ignore

--- a/scripts/collect-android-crash-logs.sh
+++ b/scripts/collect-android-crash-logs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Collect crash evidence from the emulator after a failed harness attempt.
+# Must run inside the android-emulator-runner script: the action kills the
+# emulator when that step ends, so later workflow steps cannot reach adb.
+#
+# Usage: collect-android-crash-logs.sh <attempt-label> <output-dir>
+#
+# The dedicated crash buffer and an unfiltered main-buffer dump are saved per
+# attempt (the main buffer is a ring, so waiting until the last attempt loses
+# the earlier ones). With the "final" label it also pulls /data/tombstones —
+# that needs `adb root`, which restarts adbd, so it is kept out of the
+# per-attempt path to avoid breaking the next harness attempt's connection.
+set +e
+
+attempt="${1:?attempt label required}"
+out="${2:?output dir required}"
+mkdir -p "$out"
+
+echo "=== Collecting crash logs (attempt $attempt) ==="
+adb logcat -d -b crash > "$out/attempt-$attempt-crash-buffer.txt" 2>&1
+adb logcat -d > "$out/attempt-$attempt-logcat.txt" 2>&1
+
+echo "--- crash buffer ---"
+tail -100 "$out/attempt-$attempt-crash-buffer.txt"
+echo "--- fatal lines in main buffer ---"
+grep -E 'FATAL EXCEPTION|Fatal signal|AndroidRuntime| DEBUG +: | libc +: ' \
+  "$out/attempt-$attempt-logcat.txt" | tail -50
+
+# Clear the buffers so the next attempt's dump only contains its own crash.
+adb logcat -c -b main,system,crash 2>/dev/null
+
+if [ "$attempt" = "final" ]; then
+  if adb root >/dev/null 2>&1; then
+    adb wait-for-device
+    adb pull /data/tombstones "$out/tombstones" 2>/dev/null \
+      || echo "No tombstones to pull"
+  else
+    echo "adb root unavailable, capturing bugreport instead"
+    adb bugreport "$out/bugreport.zip"
+  fi
+fi
+
+exit 0


### PR DESCRIPTION
The android harness jobs flakily die with "App bridge disconnected" / "[birpc] rpc is closed", but the failure-path debug step has never captured the actual crash: its `-s ReactNativeJS:* RNRive:*` filter silences AndroidRuntime and DEBUG/libc, it never reads the crash buffer, and it runs after android-emulator-runner has already killed the emulator, so `adb logcat` has nothing to talk to.

This adds `scripts/collect-android-crash-logs.sh` and calls it from inside the retry loop (while the emulator is still alive): after each failed attempt it dumps the crash buffer plus an unfiltered logcat (per attempt, since the ring buffer rotates across retries), and after the final attempt it pulls `/data/tombstones` via `adb root` (kept out of the per-attempt path because the adbd restart could break the next attempt's connection). Collected files are uploaded as `android-harness-crash-logs` / `android-harness-legacy-crash-logs` artifacts, mirroring the iOS crash-report steps.