### PR TITLE
docs: alignment is supported, remove stale "coming soon" note

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The following table compares feature availability with the [previous Rive React 
 | Artboard selection                | ✅     | Specify artboard to render                                       |
 | State machine selection           | ✅     | Specify a state machine to play                                  |
 | View autoPlay & play/pause        | ✅     | Control view playback                                            |
-| Fit & Alignment                   | ✅     | Fit modes supported, alignment coming soon                       |
+| Fit & Alignment                   | ✅     | Fit and alignment modes supported                                |
 | Layout & Responsiveness           | ✅     | Basic responsive layouts supported                               |
 | Data Binding                      | ✅     | Control data binding through runtime code                        |
 | Asset management                  | ✅     | Load assets out of band (referenced)                             |


### PR DESCRIPTION
The feature table still said "alignment coming soon", but the `alignment` prop is implemented end to end (`src/specs/RiveView.nitro.ts`, `src/core/Alignment.ts`, and both native views). Updates the row description to match.