### PR TITLE
fix: pin npm down to v11 as latest compatible version for our node runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - run: yarn install --immutable
 


### PR DESCRIPTION
npm v12 recently got released which dropped support for our pinned `.nvmrc` node version. We can look at updating that separately, but pinning to npm v11 should unblock npm publishing.