### PR TITLE
fix(android): make play() start the configured state machine on cold start

### DIFF
--- a/android/src/main/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/main/java/com/rive/RiveReactNativeView.kt
@@ -95,6 +95,7 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
   private var eventListeners: MutableList<RiveFileController.RiveEventListener> = mutableListOf()
   private val viewReadyDeferred = CompletableDeferred<Boolean>()
   private var _activeStateMachineName: String? = null
+  private var configuredStateMachineName: String? = null
   private var willDispose = false
 
   init {
@@ -151,6 +152,7 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
         riveAnimationView?.play(settleInitialState = false)
       }
       _activeStateMachineName = getSafeStateMachineName()
+      configuredStateMachineName = config.stateMachineName
     } else {
       riveAnimationView?.alignment = config.alignment
       riveAnimationView?.fit = config.fit
@@ -215,10 +217,30 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
   }
 
   fun play() {
-    if (_activeStateMachineName == null) {
-      _activeStateMachineName = getSafeStateMachineName()
+    val view = riveAnimationView ?: return
+    val stateMachineToStart = stateMachineToStartExplicitly(view)
+
+    if (stateMachineToStart != null) {
+      view.play(stateMachineToStart, isStateMachine = true)
+      _activeStateMachineName = stateMachineToStart
+    } else {
+      if (_activeStateMachineName == null) {
+        _activeStateMachineName = getSafeStateMachineName()
+      }
+      view.play()
     }
-    riveAnimationView?.play()
+  }
+
+  // No-arg play() resumes paused instances and starts linear animations, but
+  // on a cold start it would pick the artboard's first state machine rather
+  // than the configured one (#332) — that case needs an explicit start.
+  private fun stateMachineToStartExplicitly(view: ReactNativeRiveAnimationView): String? {
+    val controller = view.controller
+    val hasInstances =
+      controller.stateMachines.isNotEmpty() || controller.animations.isNotEmpty()
+    if (hasInstances) return null
+    return configuredStateMachineName
+      ?: controller.activeArtboard?.stateMachineNames?.firstOrNull()
   }
 
   fun pause() = riveAnimationView?.pause()

--- a/example/__tests__/play-after-autoplay-false.harness.tsx
+++ b/example/__tests__/play-after-autoplay-false.harness.tsx
@@ -1,0 +1,122 @@
+import {
+  describe,
+  it,
+  expect,
+  render,
+  waitFor,
+  cleanup,
+} from 'react-native-harness';
+import { useEffect } from 'react';
+import { View } from 'react-native';
+import {
+  RiveView,
+  RiveFileFactory,
+  Fit,
+  DataBindMode,
+  type RiveFile,
+  type RiveViewRef,
+} from '@rive-app/react-native';
+
+// rating.riv: single artboard with state machine "State Machine 1" and a
+// number input "rating".
+const RATING = require('../assets/rive/rating.riv');
+
+// Issue #332 follow-up: play() on a view mounted with autoPlay={false} must
+// start the *configured* state machine and leave its inputs writable. On
+// Android it used to fall through to rive-android's no-arg play() (first raw
+// animation + first state machine) without tracking the active machine, so
+// input writes threw "View not configured".
+
+type TestContext = {
+  ref: RiveViewRef | null;
+  error: string | null;
+};
+
+function RatingView({
+  file,
+  autoPlay,
+  context,
+}: {
+  file: RiveFile;
+  autoPlay: boolean;
+  context: TestContext;
+}) {
+  useEffect(() => {
+    return () => {
+      context.ref = null;
+    };
+  }, [context]);
+
+  return (
+    <View style={{ width: 200, height: 200 }}>
+      <RiveView
+        hybridRef={{
+          f: (ref: RiveViewRef | null) => {
+            context.ref = ref;
+          },
+        }}
+        style={{ flex: 1 }}
+        file={file}
+        autoPlay={autoPlay}
+        stateMachineName="State Machine 1"
+        dataBind={DataBindMode.None}
+        fit={Fit.Contain}
+        onError={(e) => {
+          context.error = e.message;
+        }}
+      />
+    </View>
+  );
+}
+
+async function mountRatingView(autoPlay: boolean): Promise<TestContext> {
+  const file = await RiveFileFactory.fromSource(RATING, undefined);
+  const context: TestContext = { ref: null, error: null };
+
+  await render(
+    <RatingView file={file} autoPlay={autoPlay} context={context} />
+  );
+
+  await waitFor(
+    () => {
+      expect(context.ref).not.toBeNull();
+    },
+    { timeout: 5000 }
+  );
+  await context.ref!.awaitViewReady();
+  return context;
+}
+
+// Polls until the input accepts a write, i.e. the state machine is instanced
+// and tracked.
+async function waitForWritableInput(context: TestContext): Promise<void> {
+  await waitFor(
+    () => {
+      context.ref!.setNumberInputValue('rating', 3);
+      expect(context.ref!.getNumberInputValue('rating')).toBe(3);
+    },
+    { timeout: 4000 }
+  );
+}
+
+describe('play() after autoPlay={false} (issue #332 follow-up)', () => {
+  it('control: autoPlay={true} exposes a writable state machine input', async () => {
+    const context = await mountRatingView(true);
+
+    await waitForWritableInput(context);
+
+    expect(context.error).toBeNull();
+    cleanup();
+  });
+
+  it('play() starts the configured state machine with writable inputs', async () => {
+    const context = await mountRatingView(false);
+
+    await context.ref!.play();
+
+    await waitForWritableInput(context);
+
+    expect(context.error).toBeNull();
+    cleanup();
+  });
+});


### PR DESCRIPTION
On Android, calling `play()` on a view mounted with `autoPlay={false}` didn't start the configured state machine: nothing is instanced at that point, so the wrapper fell through to rive-android's no-arg `controller.play()`, which starts the artboard's first raw animation plus its first state machine (ignoring `stateMachineName`). The result was wrong content (two timelines fighting) and, because the wrapper sampled the active state machine name before anything existed, subsequent input writes threw "View not configured. Could not find active state machine name". Reported in the follow-up of #332 ("play/playIfNeeded didn't work"); iOS was unaffected.

`play()` now starts the configured state machine explicitly on cold start (falling back to the artboard's first, matching what `autoplay` does) and records it as active. The no-arg resume path is kept for `pause()`/`play()` cycles and for animation-only files.

Includes a harness test that fails without the fix ("View not configured") and passes with it; verified on the Android emulator harness (full suite green) and on iOS (passes before and after).

Refs #332