### PR TITLE
ci: file issue on publish failure and verify release is on npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      issues: write
     steps:
       - uses: actions/checkout@v6
 
@@ -26,3 +27,31 @@ jobs:
       - run: yarn prepare
 
       - run: npm publish --provenance --access public ${{ github.event.release.prerelease && '--tag next' || ''}}
+
+      - name: Verify package is available on npm
+        run: |
+          PKG=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          for i in $(seq 1 10); do
+            if npm view "$PKG@$VERSION" version > /dev/null 2>&1; then
+              echo "$PKG@$VERSION is live on npm"
+              exit 0
+            fi
+            echo "$PKG@$VERSION not visible on npm yet, retrying in 30s ($i/10)"
+            sleep 30
+          done
+          echo "$PKG@$VERSION did not appear on npm"
+          exit 1
+
+      - name: File issue on publish failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "npm publish failed for ${{ github.event.release.tag_name }}" \
+            --body "The publish workflow for release \`${{ github.event.release.tag_name }}\` failed, so this version is likely not on npm.
+
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          cc @mfazekas @zplata"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,4 +54,4 @@ jobs:
 
           Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-          cc @mfazekas @zplata"
+          cc @mfazekas"


### PR DESCRIPTION
The v0.4.15–v0.4.17 publish failures went unnoticed for three releases because releases are created via the release-please PAT, so GitHub's workflow-failure emails only go to the `rive-engineering` account. This adds two safeguards to the publish workflow:

1. After `npm publish`, poll the registry (up to 5 minutes) until the published version is actually visible, so a run only goes green once the package is really live.
2. If any step fails, automatically file an issue on the repo with a link to the failed run and cc the maintainers, so failures surface where people actually look.

Needs `issues: write` on the job, otherwise uses the default `GITHUB_TOKEN` — no new secrets.