### PR TITLE
fix(ios): don't surface RiveUIView's transient missing-drawable draw log as a LogBox error

### DIFF
--- a/ios/new/RiveRuntimeLogger.swift
+++ b/ios/new/RiveRuntimeLogger.swift
@@ -17,40 +17,67 @@ private func tagName(_ tag: RiveRuntime.RiveLog.Tag) -> String {
     }
 }
 
+/// The SDK hardcodes the tag name into its message strings (e.g. "[RiveUIView]
+/// Draw failed…") in addition to passing `tag:`, so prepending the tag again in
+/// `RiveLog` would print it twice.
+private func stripTagPrefix(_ message: String, tag: String) -> String {
+    let prefix = "[\(tag)] "
+    guard message.hasPrefix(prefix) else { return message }
+    return String(message.dropFirst(prefix.count))
+}
+
 /// Implements the Rive iOS SDK's `RiveLog.Logger` protocol and forwards all
 /// C++ runtime logs through our bridge-level `RiveLog` utility, giving JS
 /// visibility into file, artboard, state machine, and view model diagnostics.
 final class RiveRuntimeLogger: RiveRuntime.RiveLog.Logger, @unchecked Sendable {
     func notice(tag: RiveRuntime.RiveLog.Tag, _ message: @escaping () -> String) {
-        RiveLog.i(tagName(tag), message())
+        let name = tagName(tag)
+        RiveLog.i(name, stripTagPrefix(message(), tag: name))
     }
 
     func debug(tag: RiveRuntime.RiveLog.Tag, _ message: @escaping () -> String) {
-        RiveLog.d(tagName(tag), message())
+        let name = tagName(tag)
+        RiveLog.d(name, stripTagPrefix(message(), tag: name))
     }
 
     func trace(tag: RiveRuntime.RiveLog.Tag, _ message: @escaping () -> String) {
-        RiveLog.d(tagName(tag), message())
+        let name = tagName(tag)
+        RiveLog.d(name, stripTagPrefix(message(), tag: name))
     }
 
     func info(tag: RiveRuntime.RiveLog.Tag, _ message: @escaping () -> String) {
-        RiveLog.i(tagName(tag), message())
+        let name = tagName(tag)
+        RiveLog.i(name, stripTagPrefix(message(), tag: name))
     }
 
     func error(tag: RiveRuntime.RiveLog.Tag, error: (any Error)?, _ message: @escaping () -> String) {
+        let name = tagName(tag)
+        let text = stripTagPrefix(message(), tag: name)
         let suffix = error.map { " (\($0.localizedDescription))" } ?? ""
-        RiveLog.e(tagName(tag), "\(message())\(suffix)")
+        // RiveUIView draws its MTKView before Auto Layout has sized it, so the
+        // first frame(s) have no drawable yet; the SDK logs that transient
+        // condition at error level, which LogBox turns into a red screen in dev.
+        // Rendering recovers on the next tick, so forward it as debug instead.
+        // https://github.com/rive-app/rive-ios/blob/6.21.1/Source/Concurrency/View/RiveUIView.swift#L449-L454
+        if case .view = tag, text == "Draw failed: missing drawable" {
+            RiveLog.d(name, "\(text)\(suffix)")
+            return
+        }
+        RiveLog.e(name, "\(text)\(suffix)")
     }
 
     func warning(tag: RiveRuntime.RiveLog.Tag, _ message: @escaping () -> String) {
-        RiveLog.w(tagName(tag), message())
+        let name = tagName(tag)
+        RiveLog.w(name, stripTagPrefix(message(), tag: name))
     }
 
     func fault(tag: RiveRuntime.RiveLog.Tag, _ message: @escaping () -> String) {
-        RiveLog.e(tagName(tag), message())
+        let name = tagName(tag)
+        RiveLog.e(name, stripTagPrefix(message(), tag: name))
     }
 
     func critical(tag: RiveRuntime.RiveLog.Tag, _ message: @escaping () -> String) {
-        RiveLog.e(tagName(tag), message())
+        let name = tagName(tag)
+        RiveLog.e(name, stripTagPrefix(message(), tag: name))
     }
 }


### PR DESCRIPTION
Opening any Rive page in the Debug example app pops a LogBox red screen reading `[RiveUIView] [RiveUIView] Draw failed: missing drawable`. The SDK's `RiveUIView` force-draws its MTKView before Auto Layout has sized it, so `currentDrawable` is nil for the first frame(s); it logs that transient condition at error level and rendering recovers on the next tick. rive-ios 6.21.1 is the latest release and upstream `main` has no change here, so `RiveRuntimeLogger` now forwards this specific `.view` message at debug instead of error.

Also strips the tag prefix the SDK hardcodes into its message strings (it already passes the same tag separately), which caused the doubled `[RiveUIView] [RiveUIView]` above.

Verified on an iPhone 17 / iOS 26.5 simulator: unfixed build shows the red screen on Quick Start; with the fix the same `CAMetalLayer nextDrawable returning nil` still occurs in the device log but nothing is forwarded at error level, no LogBox appears, and the animation renders.