### PR TITLE
fix(ios): force fmt 12.1.0 in the example so it compiles on Xcode 26.4+

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -10,6 +10,30 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
+# fmt `consteval` build error on Xcode 26.4+ (Apple clang 21): RN 0.80's bundled fmt 11.0.2
+# fails to compile (expo/expo#44229, facebook/react-native#55601), and it predates both the
+# FMT_USE_CONSTEVAL escape hatch (fmt 11.1) and the real code fix (fmt 12.x, shipped with
+# RN 0.83+). Force fmt 12.1.0 — the exact version RN 0.86 ships — by rewriting the vendored
+# podspecs before dependency resolution (RCT-Folly exact-pins fmt, so its podspec must be
+# relaxed too). Re-runs on every `pod install`, so it survives `yarn install` re-extraction.
+# Drop this once the example is on RN >= 0.83.
+rn_podspecs = File.expand_path('../node_modules/react-native/third-party-podspecs', __dir__)
+{
+  'fmt.podspec' => [['"11.0.2"', '"12.1.0"']],
+  'RCT-Folly.podspec' => [['spec.dependency "fmt", "11.0.2"', 'spec.dependency "fmt", "12.1.0"']],
+}.each do |file, subs|
+  path = File.join(rn_podspecs, file)
+  contents = File.read(path)
+  patched = subs.reduce(contents) { |c, (from, to)| c.gsub(from, to) }
+  if patched != contents
+    File.write(path, patched)
+    Pod::UI.puts "Forced fmt 12.1.0 in #{file} (Xcode 26.4+ consteval fix)".green
+  end
+  # CocoaPods reuses cached podspec JSONs even when the .podspec changed underneath it
+  cached = File.join(__dir__, 'Pods', 'Local Podspecs', "#{file}.json")
+  File.delete(cached) if File.exist?(cached) && File.read(cached).include?('11.0.2')
+end
+
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
   Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
@@ -34,22 +58,5 @@ target 'RiveExample' do
       # :ccache_enabled => true
     )
 
-    # fmt `consteval` build error on Xcode 26.4+ (Apple clang 21): the compiler rejects
-    # fmt's compile-time FMT_STRING (basic_format_string's consteval ctor) as a
-    # non-constant-expression. Disable fmt's consteval path via FMT_USE_CONSTEVAL=0 while
-    # keeping C++20 — this is the interim workaround Expo recommends (expo/expo#44229) and
-    # mirrors what fmt itself does for broken-consteval compilers (fmt/base.h sets
-    # FMT_USE_CONSTEVAL 0 for e.g. Apple clang < 14). Preferred over compiling the fmt pod as
-    # C++17 because it keeps the whole graph on a single C++ standard. Real fix is upstream in
-    # React Native 0.83+ (fmtlib/fmt#4740, facebook/react-native#55601); remove once we bump.
-    installer.pods_project.targets.each do |target|
-      next unless target.name == 'fmt'
-      target.build_configurations.each do |bc|
-        defs = bc.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
-        defs = [defs] unless defs.is_a?(Array)
-        defs << 'FMT_USE_CONSTEVAL=0' unless defs.include?('FMT_USE_CONSTEVAL=0')
-        bc.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = defs
-      end
-    end
   end
 end


### PR DESCRIPTION
RN 0.80's bundled fmt 11.0.2 fails to compile on Xcode 26.4+ (Apple clang 21 rejects fmt's consteval `FMT_STRING` path, expo/expo#44229). The `FMT_USE_CONSTEVAL=0` build setting the Podfile used never took effect: fmt 11.0.2 predates the `#ifdef` escape hatch (added in fmt 11.1) and unconditionally re-defines the macro.

Instead of patching fmt sources, force fmt 12.1.0 — the version RN 0.86 ships, where the consteval code is fixed upstream — by rewriting the vendored `fmt.podspec` and `RCT-Folly.podspec` (which exact-pins fmt) before dependency resolution, and dropping stale `Pods/Local Podspecs` JSONs that CocoaPods would otherwise reuse. First install after this change needs `pod update fmt` or `rm Podfile.lock` (CI already deletes the lock). Drop the whole block once the example is on RN >= 0.83.

Verified on Xcode 26.5: full example build succeeds and the iOS harness suite passes (26 suites / 204 tests).