### PR TITLE
docs: adopt Rive's "new runtime" / "legacy runtime" terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,6 @@ When you're sending a pull request:
 
 ## Runtime backends
 
-The legacy backend exists for behavior comparison during the experimental
+The legacy backend exists for behavior comparison during the new-runtime
 rollout — see [docs/runtime-backends.md](docs/runtime-backends.md) for how to
 select it and the behavioral differences to compare against.

--- a/android/src/new/java/com/margelo/nitro/rive/HybridRiveFile.kt
+++ b/android/src/new/java/com/margelo/nitro/rive/HybridRiveFile.kt
@@ -195,7 +195,7 @@ class HybridRiveFile(
   override fun updateReferencedAssets(referencedAssets: ReferencedAssetsType) {
     RiveLog.w(
       TAG,
-      "updateReferencedAssets is not supported with the experimental backend — already-rendered artboards cannot be updated. Use the legacy backend for runtime asset swapping."
+      "updateReferencedAssets is not supported — already-rendered artboards cannot be updated. Supply assets via referencedAssets at load time instead."
     )
   }
 

--- a/docs/migrating-to-0.5.md
+++ b/docs/migrating-to-0.5.md
@@ -46,5 +46,5 @@ deprecated calls keep working with runtime warnings.
 
 ## 4. 0.6
 
-The deprecated APIs and the legacy runtime are removed. Apps that completed
+Removal of the deprecated APIs is planned for 0.6. Apps that completed
 step 1 need no further changes.

--- a/docs/migrating-to-0.5.md
+++ b/docs/migrating-to-0.5.md
@@ -1,0 +1,50 @@
+# Migrating to 0.5 (the new Rive runtime)
+
+0.5 switches the library to Rive's new CommandQueue-based runtime
+([New Runtime](https://rive.app/docs/runtimes/apple/apple) on iOS,
+[New Compose API](https://rive.app/docs/runtimes/android) on Android) and
+completes the move to the async JS API. The recommended path:
+
+## 1. On the latest 0.4.x: move to the async APIs
+
+The full async surface already ships in 0.4 — migrate there first, while
+everything still behaves exactly as before. Your editor's deprecation
+strikethroughs point at each replacement:
+
+| Deprecated                                                                                              | Use instead                                                                           |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `property.value` (read / write)                                                                         | `getValueAsync()` / `set(value)`                                                      |
+| `viewModel(path)`                                                                                       | `viewModelAsync(path)`                                                                |
+| `createInstanceByName/ByIndex`, `createDefaultInstance`, `createInstance`                               | `createInstanceByNameAsync`, `createDefaultInstanceAsync`, `createBlankInstanceAsync` |
+| `viewModelByName/ByIndex`, `defaultArtboardViewModel`                                                   | `viewModelByNameAsync`, `defaultArtboardViewModelAsync`                               |
+| list `length`, `getInstanceAt`, `addInstance(At)`, `removeInstance(At)`, `swap`                         | the `*Async` equivalents                                                              |
+| `artboardNames`, `artboardCount`, `viewModelCount`, `propertyCount`, `instanceCount`, `getEnums` (sync) | the `*Async` equivalents                                                              |
+| `useViewModelInstance(file)` (sync creation)                                                            | `useViewModelInstance(file, { async: true })`                                         |
+| state-machine inputs / text runs / Rive events on the view                                              | [data binding](https://rive.app/docs/runtimes/data-binding)                           |
+
+## 2. Try the 0.5 beta
+
+```sh
+npm install @rive-app/react-native@next
+```
+
+The new runtime is now the default. Things to know:
+
+- Deprecated sync APIs still work, but they block the JS thread and log a
+  once-per-member `[Rive/Deprecation]` warning.
+- The deprecated state-machine-input, text-run, and Rive-event view methods
+  **throw** — data binding replaces them.
+- Property accessors (`numberProperty(path)` etc.) return unvalidated
+  handles; a typo'd path surfaces via the `getValueAsync()` rejection or the
+  `useRive*` hooks' `error` result instead of an `undefined` return.
+- `updateReferencedAssets` (runtime asset swapping) is not supported.
+
+## 3. 0.5 stable
+
+Same behavior as the beta: fully migrated apps run warning-free; remaining
+deprecated calls keep working with runtime warnings.
+
+## 4. 0.6
+
+The deprecated APIs and the legacy runtime are removed. Apps that completed
+step 1 need no further changes.

--- a/docs/riv-files.md
+++ b/docs/riv-files.md
@@ -10,11 +10,11 @@ Properties of all .riv files used in this project.
 |------|----|----|-----|-------|
 | `quick_start.riv` | Yes | Yes | Yes | Artboard: `health_bar_v01`. VM props: `health` (number), `gameOver` (trigger). Game health/damage system. |
 | `databinding.riv` | Yes | Yes | Yes | Primary data binding test file. `Person` VM with: `age` (number), `name` (string), `likes_popcorn` (bool), `favourite_color` (color), `favourite_pet` (enum), `jump` (trigger). Nested `pet` VM. Enum `Pets`: dog/cat/frog/owl/chipmunk/rat. 2 view models total. |
-| `databinding_lists.riv` | Yes | Yes | - | `DevRel` VM with `team` list property. Default 5 items. Tests list mutations (exercised on the experimental backend by `databinding-advanced` / `async-api` harness suites). |
-| `databinding_images.riv` | Yes | Yes | - | `MyViewModel` with `bound_image` image property. Runs on the experimental backend (covered by harness suites). |
-| `artboard_db_test.riv` | Yes | Yes | - | Multiple artboards, artboard properties: `artboard_1`, `artboard_2`. Runs on the experimental backend (covered by harness suites). |
+| `databinding_lists.riv` | Yes | Yes | - | `DevRel` VM with `team` list property. Default 5 items. Tests list mutations (exercised on the new runtime by `databinding-advanced` / `async-api` harness suites). |
+| `databinding_images.riv` | Yes | Yes | - | `MyViewModel` with `bound_image` image property. Runs on the new runtime (covered by harness suites). |
+| `artboard_db_test.riv` | Yes | Yes | - | Multiple artboards, artboard properties: `artboard_1`, `artboard_2`. Runs on the new runtime (covered by harness suites). |
 | `viewmodelproperty.riv` | Yes | Yes | - | Complex nested VMs: `vm1`/`vm2` instances with nested `pet` VM. Tests replaceViewModel(). |
-| `rewards.riv` | Yes | Yes | Yes | Bouncing chest animation by default. Nested property paths: `Coin/Item_Value` (number), `Button/State_1` (string), `Energy_Bar/Bar_Color` (color), `Button/Pressed` (trigger). Works with experimental runtime. |
+| `rewards.riv` | Yes | Yes | Yes | Bouncing chest animation by default. Nested property paths: `Coin/Item_Value` (number), `Button/State_1` (string), `Energy_Bar/Bar_Color` (color), `Button/Pressed` (trigger). Works with the new runtime. |
 | `many_viewmodels.riv` | Yes | Yes | - | Named instances: `red`, `green`, `blue`. Image property: `imageValue`. |
 | `rating.riv` | Yes | No | No | Static 5-star selector — no auto-play animation, only responds to SM number input: `rating` (0-5). |
 | `out_of_band.riv` | Yes | No | - | SM: `State Machine 1`. OOB image (`referenced-image-2929282`), font (`Inter-594377`), audio (`referenced_audio-2929340`). |
@@ -40,16 +40,16 @@ Properties of all .riv files used in this project.
 
 | URL | SM | DB | AP | Notes |
 |-----|----|----|-----|-------|
-| `cdn.rive.app/animations/vehicles.riv` | **No** | No | Yes | Endless looping vehicle parade. No state machine, no interactivity. **Does not work with experimental iOS runtime** (requires SM). |
-| `cdn.rive.app/animations/off_road_car_v7.riv` | **No** | No | Yes | Off-road car with idle/bouncing/windshield_wipers timeline animations. No state machine. **Does not work with experimental iOS runtime**. |
+| `cdn.rive.app/animations/vehicles.riv` | **No** | No | Yes | Endless looping vehicle parade. No state machine, no interactivity. **Does not work with the new iOS runtime** (requires SM). |
+| `cdn.rive.app/animations/off_road_car_v7.riv` | **No** | No | Yes | Off-road car with idle/bouncing/windshield_wipers timeline animations. No state machine. **Does not work with the new iOS runtime**. |
 
-## Experimental Backend Compatibility
+## New Runtime Compatibility
 
 Historical note: `databinding_images.riv`, `artboard_db_test.riv`, and
-`databinding_lists.riv` list mutations crashed early experimental builds
+`databinding_lists.riv` list mutations crashed early new-runtime builds
 (EXC_BAD_ACCESS); all three are now exercised green by the harness suites CI
-runs on the experimental backend.
+runs on the new runtime.
 
-Files that **don't work** with experimental backend:
-- `vehicles.riv` (remote) - no state machine, experimental API requires one
+Files that **don't work** with new runtime:
+- `vehicles.riv` (remote) - no state machine, the new runtime requires one
 - `swap_character_assets.riv` - no state machine (asset-only file)

--- a/docs/runtime-backends.md
+++ b/docs/runtime-backends.md
@@ -26,8 +26,9 @@ proven out. Select it at build time:
   ```
 
 You can check which backend is active at runtime via
-`RiveFileFactory.getBackend()` (`'experimental' | 'legacy'` — the string
-`'experimental'` identifies the new runtime; it is kept for API stability).
+`RiveFileFactory.getBackend()` (`'experimental' | 'legacy'`, where
+`'experimental'` is the new runtime). This API is for internal testing only —
+it and the legacy runtime will be removed in 0.6.
 
 Behavioral differences on the new runtime:
 

--- a/docs/runtime-backends.md
+++ b/docs/runtime-backends.md
@@ -28,7 +28,8 @@ proven out. Select it at build time:
 You can check which backend is active at runtime via
 `RiveFileFactory.getBackend()` (`'experimental' | 'legacy'`, where
 `'experimental'` is the new runtime). This API is for internal testing only —
-it and the legacy runtime will be removed in 0.6.
+it and the legacy runtime will be removed in a future release once the new
+runtime has fully proven out (not necessarily 0.6).
 
 Behavioral differences on the new runtime:
 

--- a/docs/runtime-backends.md
+++ b/docs/runtime-backends.md
@@ -1,10 +1,10 @@
 # Runtime backends (contributor guide)
 
-The library ships two native backends and uses the **experimental** Rive
+The library ships two native backends and uses the **new** Rive
 runtime backend (Rive's CommandQueue-based async API) by default. The
 previous implementation is kept as the **legacy** backend **for development
 and behavior comparison only** — it is not a supported end-user
-configuration and will be removed once the experimental backend has fully
+configuration and will be removed once the new runtime has fully
 proven out. Select it at build time:
 
 - **iOS** — set the Podfile global before `pod install`:
@@ -16,7 +16,7 @@ proven out. Select it at build time:
 
   (`USE_RIVE_LEGACY=1 pod install` also works, but the env var only applies
   to that invocation — any plain `pod install` afterwards silently switches
-  the project back to the experimental backend, so prefer the Podfile
+  the project back to the new runtime, so prefer the Podfile
   global.)
 
 - **Android** — set the Gradle property, e.g. in `android/gradle.properties`:
@@ -26,9 +26,10 @@ proven out. Select it at build time:
   ```
 
 You can check which backend is active at runtime via
-`RiveFileFactory.getBackend()` (`'experimental' | 'legacy'`).
+`RiveFileFactory.getBackend()` (`'experimental' | 'legacy'` — the string
+`'experimental'` identifies the new runtime; it is kept for API stability).
 
-Behavioral differences on the experimental backend:
+Behavioral differences on the new runtime:
 
 - The deprecated state-machine-input, text-run, and Rive-event view methods
   throw — use [data binding](https://rive.app/docs/runtimes/data-binding)
@@ -38,9 +39,9 @@ Behavioral differences on the experimental backend:
   `useRive*` hooks' `error` result instead of an `undefined` return.
 - `updateReferencedAssets` (runtime asset swapping) is not supported.
 
-## Android render backend (experimental backend only)
+## Android render backend (new runtime only)
 
-The experimental Android backend renders with OpenGL by default. Vulkan can
+The new Android runtime renders with OpenGL by default. Vulkan can
 be opted into per process:
 
 ```ts

--- a/example/__tests__/asset-loading.harness.ts
+++ b/example/__tests__/asset-loading.harness.ts
@@ -9,7 +9,7 @@ function isExperimental() {
 
 describe('Asset loading with referencedAssets', () => {
   // referencedAssets with raw ResolvedReferencedAsset objects only works
-  // on the experimental backend; legacy uses a different resolution path.
+  // on the new runtime; legacy uses a different resolution path.
   it('loads file with font asset (type: font)', async () => {
     if (!isExperimental()) return;
     const file = await RiveFileFactory.fromSource(OUT_OF_BAND, {

--- a/example/__tests__/async-api.harness.ts
+++ b/example/__tests__/async-api.harness.ts
@@ -63,7 +63,7 @@ describe('Async ViewModel Creation', () => {
       const instance = await vm.createInstanceByNameAsync('__DoesNotExist__');
       expect(instance).toBeUndefined();
     } catch {
-      // experimental backend may throw
+      // new runtime may throw
     }
   });
 
@@ -275,7 +275,7 @@ describe('Async ViewModelInstance Methods', () => {
         expect(result).toBeUndefined();
       }
     } catch {
-      // experimental backend may throw
+      // new runtime may throw
     }
   });
 

--- a/example/__tests__/autoplay.harness.tsx
+++ b/example/__tests__/autoplay.harness.tsx
@@ -329,7 +329,7 @@ describe('imperative playback control (play/pause/reset)', () => {
     cleanup();
   });
 
-  // reset() is deprecated and a no-op on the experimental backend (no reset
+  // reset() is deprecated and a no-op on the new runtime (no reset
   // primitive in the runtime); it logs an error and resolves without throwing.
   it('reset() resolves without throwing (deprecated no-op)', async () => {
     const { file, instance } = await loadBouncingBall();

--- a/example/__tests__/bind-before-ready.harness.tsx
+++ b/example/__tests__/bind-before-ready.harness.tsx
@@ -27,7 +27,7 @@ const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe('bindViewModelInstance before view ready', () => {
   it('bind called before configure completes is applied', async () => {
-    // The race only exists on iOS experimental — riveInstance is set async
+    // The race only exists on the new iOS runtime — riveInstance is set async
     if (
       Platform.OS !== 'ios' ||
       RiveFileFactory.getBackend() !== 'experimental'

--- a/example/__tests__/databinding-advanced.harness.ts
+++ b/example/__tests__/databinding-advanced.harness.ts
@@ -121,7 +121,7 @@ describe('ViewModel Creation Variants', () => {
       const instance = vm.createInstanceByName('DoesNotExist');
       expect(instance).toBeUndefined();
     } catch {
-      // experimental backend throws - that's fine
+      // new runtime throws - that's fine
     }
   });
 

--- a/example/__tests__/play-after-autoplay-false.harness.tsx
+++ b/example/__tests__/play-after-autoplay-false.harness.tsx
@@ -104,7 +104,7 @@ async function waitForWritableInput(context: TestContext): Promise<void> {
 // backends (both platforms).
 function skipOnExperimental(): boolean {
   if (RiveFileFactory.getBackend() === 'experimental') {
-    console.warn('SKIP: experimental backend — SMI inputs are not supported');
+    console.warn('SKIP: new runtime — SMI inputs are not supported');
     return true;
   }
   return false;

--- a/example/__tests__/reconfigure.harness.tsx
+++ b/example/__tests__/reconfigure.harness.tsx
@@ -53,7 +53,7 @@ function SwitchableRiveView({
 
 describe('RiveView reconfigure (file switch)', () => {
   it('animation still plays after switching file prop and back', async () => {
-    // Fix only applies to iOS experimental — setupRiveUIView teardown churn
+    // Fix only applies to the new iOS runtime — setupRiveUIView teardown churn
     if (
       Platform.OS !== 'ios' ||
       RiveFileFactory.getBackend() !== 'experimental'

--- a/example/__tests__/rivelog.harness.tsx
+++ b/example/__tests__/rivelog.harness.tsx
@@ -7,7 +7,7 @@ const isExperimental = RiveFileFactory.getBackend() === 'experimental';
 type LogEntry = { level: string; tag: string; message: string };
 
 describe('RiveLog', () => {
-  // Deprecation warnings only fire in the experimental backend
+  // Deprecation warnings only fire in the new runtime
   (isExperimental ? it : it.skip)(
     'captures deprecation warning from sync method',
     async () => {

--- a/example/__tests__/use-rive-trigger.harness.tsx
+++ b/example/__tests__/use-rive-trigger.harness.tsx
@@ -191,7 +191,7 @@ describe('useRiveTrigger hook', () => {
 
     expect(context.error).toBeNull();
 
-    // Wait for the experimental backend's view to be ready before firing.
+    // Wait for the new runtime's view to be ready before firing.
     await waitForViewReady(context);
 
     // Fire trigger and wait for it — pollChanges() runs on frame ticks,
@@ -243,7 +243,7 @@ describe('useRiveTrigger hook', () => {
 
     expect(context.error).toBeNull();
 
-    // Wait for the experimental backend's view to be ready before firing.
+    // Wait for the new runtime's view to be ready before firing.
     await waitForViewReady(context);
 
     // Fire trigger AFTER the re-render burst — before the fix, this was lost

--- a/example/__tests__/view-methods.harness.tsx
+++ b/example/__tests__/view-methods.harness.tsx
@@ -96,11 +96,11 @@ describe('RiveView methods', () => {
   });
 });
 
-// The headline behavioral break of the experimental backend: the deprecated
+// The headline behavioral break of the new runtime: the deprecated
 // SMI-input / text-run / event methods throw instead of being implemented.
 // Guards the documented contract (specs say "Throws on the experimental
 // backend") — if an implementation lands, update the docs and these tests.
-describe('deprecated RiveView methods throw on the experimental backend', () => {
+describe('deprecated RiveView methods throw on the new runtime', () => {
   const mountView = async () => {
     const file = await RiveFileFactory.fromSource(BOUNCING_BALL, undefined);
     const context: TestContext = { ref: null, error: null };

--- a/example/__tests__/viewmodel-properties.harness.ts
+++ b/example/__tests__/viewmodel-properties.harness.ts
@@ -284,7 +284,7 @@ describe('Property Listeners', () => {
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe('Listener callback invocation (experimental only)', () => {
-  // The experimental backend emits the current value on addListener;
+  // The new runtime emits the current value on addListener;
   // legacy only fires on subsequent changes — these tests would hang.
   it('numberProperty listener emits current value', async () => {
     if (!isExperimental()) return;

--- a/ios/new/HybridRiveFile.swift
+++ b/ios/new/HybridRiveFile.swift
@@ -164,7 +164,7 @@ class HybridRiveFile: HybridRiveFileSpec {
   }
 
   func updateReferencedAssets(referencedAssets: ReferencedAssetsType) {
-    RCTLogWarn("[Rive] updateReferencedAssets is not supported with the new runtime — already-rendered artboards cannot be updated. Use the legacy backend for runtime asset swapping.")
+    RCTLogWarn("[Rive] updateReferencedAssets is not supported — already-rendered artboards cannot be updated. Supply assets via referencedAssets at load time instead.")
   }
 
   func getEnums() throws -> Promise<[RiveEnumDefinition]> {

--- a/ios/new/HybridRiveFile.swift
+++ b/ios/new/HybridRiveFile.swift
@@ -164,7 +164,7 @@ class HybridRiveFile: HybridRiveFileSpec {
   }
 
   func updateReferencedAssets(referencedAssets: ReferencedAssetsType) {
-    RCTLogWarn("[Rive] updateReferencedAssets is not supported with the experimental backend — already-rendered artboards cannot be updated. Use the legacy backend for runtime asset swapping.")
+    RCTLogWarn("[Rive] updateReferencedAssets is not supported with the new runtime — already-rendered artboards cannot be updated. Use the legacy backend for runtime asset swapping.")
   }
 
   func getEnums() throws -> Promise<[RiveEnumDefinition]> {

--- a/ios/new/HybridRiveView.swift
+++ b/ios/new/HybridRiveView.swift
@@ -127,11 +127,11 @@ class HybridRiveView: HybridRiveViewSpec {
   }
 
   func onEventListener(onEvent: @escaping (UnifiedRiveEvent) -> Void) throws {
-    throw RuntimeError.error(withMessage: "Events are not supported in the experimental iOS API")
+    throw RuntimeError.error(withMessage: "Events are not supported by the new iOS runtime — use data binding")
   }
 
   func removeEventListeners() throws {
-    throw RuntimeError.error(withMessage: "Events are not supported in the experimental iOS API")
+    throw RuntimeError.error(withMessage: "Events are not supported by the new iOS runtime — use data binding")
   }
 
   func setNumberInputValue(name: String, value: Double, path: String?) throws {

--- a/ios/new/RiveReactNativeView.swift
+++ b/ios/new/RiveReactNativeView.swift
@@ -172,7 +172,7 @@ class RiveReactNativeView: UIView {
 
   func reset() {
     // Deprecated: the experimental Rive runtime has no reset primitive.
-    RiveLog.e("RiveReactNativeView", "reset() is deprecated and not supported on the experimental backend")
+    RiveLog.e("RiveReactNativeView", "reset() is deprecated and not supported on the new runtime")
   }
 
   func playIfNeeded() {
@@ -183,31 +183,31 @@ class RiveReactNativeView: UIView {
   }
 
   func setNumberInputValue(name: String, value: Float, path: String?) throws {
-    throw RuntimeError.error(withMessage: "SMI inputs not supported in experimental API")
+    throw RuntimeError.error(withMessage: "SMI inputs are not supported by the new runtime — use data binding")
   }
 
   func getNumberInputValue(name: String, path: String?) throws -> Float {
-    throw RuntimeError.error(withMessage: "SMI inputs not supported in experimental API")
+    throw RuntimeError.error(withMessage: "SMI inputs are not supported by the new runtime — use data binding")
   }
 
   func setBooleanInputValue(name: String, value: Bool, path: String?) throws {
-    throw RuntimeError.error(withMessage: "SMI inputs not supported in experimental API")
+    throw RuntimeError.error(withMessage: "SMI inputs are not supported by the new runtime — use data binding")
   }
 
   func getBooleanInputValue(name: String, path: String?) throws -> Bool {
-    throw RuntimeError.error(withMessage: "SMI inputs not supported in experimental API")
+    throw RuntimeError.error(withMessage: "SMI inputs are not supported by the new runtime — use data binding")
   }
 
   func triggerInput(name: String, path: String?) throws {
-    throw RuntimeError.error(withMessage: "SMI inputs not supported in experimental API")
+    throw RuntimeError.error(withMessage: "SMI inputs are not supported by the new runtime — use data binding")
   }
 
   func setTextRunValue(name: String, value: String, path: String?) throws {
-    throw RuntimeError.error(withMessage: "Text runs not supported in experimental API")
+    throw RuntimeError.error(withMessage: "Text runs are not supported by the new runtime — use data binding")
   }
 
   func getTextRunValue(name: String, path: String?) throws -> String {
-    throw RuntimeError.error(withMessage: "Text runs not supported in experimental API")
+    throw RuntimeError.error(withMessage: "Text runs are not supported by the new runtime — use data binding")
   }
 
   // MARK: - Internal

--- a/src/core/RiveFile.ts
+++ b/src/core/RiveFile.ts
@@ -13,7 +13,7 @@ const RiveFileInternal =
 let _warnedLoadCdnUnsupported = false;
 
 /**
- * The new runtime ignores `loadCdn` — its CommandQueue file-load API
+ * `loadCdn` is ignored — the runtime file-load API
  * has no CDN asset resolution. Warn once (per JS runtime) when a caller
  * *explicitly* opts into `loadCdn: true` there, so they know CDN-referenced
  * assets must be supplied via `referencedAssets` instead. Callers that don't
@@ -57,7 +57,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from a URL.
    * @param url - The URL of the Rive (.riv) file
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
+   *   Ignored — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    */
   export async function fromURL(
@@ -77,7 +77,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from a local file path URL.
    * @param pathURL - The local file path of the Rive (.riv) file
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
+   *   Ignored — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    */
   export async function fromFileURL(
@@ -97,7 +97,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from a local resource.
    * @param resource - The name of the local resource
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
+   *   Ignored — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    */
   export async function fromResource(
@@ -117,7 +117,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from raw bytes.
    * @param bytes - The raw bytes of the Rive (.riv) file
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
+   *   Ignored — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    */
   export async function fromBytes(
@@ -137,7 +137,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from a source that can be either a resource ID or a URI object.
    * @param source - Either a number representing a resource ID or an object with a uri property
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
+   *   Ignored — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    * @throws Error if the source is invalid or cannot be resolved
    * @example

--- a/src/core/RiveFile.ts
+++ b/src/core/RiveFile.ts
@@ -42,9 +42,12 @@ function warnLoadCdnUnsupportedOnExperimental(
  */
 export namespace RiveFileFactory {
   /**
-   * Which backend is in use. `'experimental'` identifies the new
-   * (CommandQueue-based) runtime — the string predates the "new runtime"
-   * naming and is kept for API stability.
+   * Which runtime is in use — `'experimental'` is the new (CommandQueue-based)
+   * runtime, `'legacy'` the previous one.
+   *
+   * @internal For internal testing only. The legacy runtime exists for
+   * behavior comparison during the rollout; it and this API will be removed
+   * in 0.6.
    */
   export function getBackend(): 'legacy' | 'experimental' {
     return RiveFileInternal.backend as 'legacy' | 'experimental';

--- a/src/core/RiveFile.ts
+++ b/src/core/RiveFile.ts
@@ -47,7 +47,7 @@ export namespace RiveFileFactory {
    *
    * @internal For internal testing only. The legacy runtime exists for
    * behavior comparison during the rollout; it and this API will be removed
-   * in 0.6.
+   * in a future release once the new runtime has fully proven out.
    */
   export function getBackend(): 'legacy' | 'experimental' {
     return RiveFileInternal.backend as 'legacy' | 'experimental';

--- a/src/core/RiveFile.ts
+++ b/src/core/RiveFile.ts
@@ -13,7 +13,7 @@ const RiveFileInternal =
 let _warnedLoadCdnUnsupported = false;
 
 /**
- * The experimental backend ignores `loadCdn` — its CommandQueue file-load API
+ * The new runtime ignores `loadCdn` — its CommandQueue file-load API
  * has no CDN asset resolution. Warn once (per JS runtime) when a caller
  * *explicitly* opts into `loadCdn: true` there, so they know CDN-referenced
  * assets must be supplied via `referencedAssets` instead. Callers that don't
@@ -29,7 +29,7 @@ function warnLoadCdnUnsupportedOnExperimental(
   ) {
     _warnedLoadCdnUnsupported = true;
     console.warn(
-      '[Rive] `loadCdn: true` is not supported on the experimental backend and is ignored. ' +
+      '[Rive] `loadCdn: true` is not supported on the new runtime and is ignored. ' +
         'CDN-referenced assets (fonts/images) are not fetched automatically — supply them ' +
         'via the `referencedAssets` option instead.'
     );
@@ -41,7 +41,11 @@ function warnLoadCdnUnsupportedOnExperimental(
  * Provides static methods to load Rive files from URLs, resources, or raw bytes.
  */
 export namespace RiveFileFactory {
-  /** Which backend is in use: "legacy" or "experimental" */
+  /**
+   * Which backend is in use. `'experimental'` identifies the new
+   * (CommandQueue-based) runtime — the string predates the "new runtime"
+   * naming and is kept for API stability.
+   */
   export function getBackend(): 'legacy' | 'experimental' {
     return RiveFileInternal.backend as 'legacy' | 'experimental';
   }
@@ -50,7 +54,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from a URL.
    * @param url - The URL of the Rive (.riv) file
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the experimental backend — supply assets via `referencedAssets` instead.
+   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    */
   export async function fromURL(
@@ -70,7 +74,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from a local file path URL.
    * @param pathURL - The local file path of the Rive (.riv) file
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the experimental backend — supply assets via `referencedAssets` instead.
+   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    */
   export async function fromFileURL(
@@ -90,7 +94,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from a local resource.
    * @param resource - The name of the local resource
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the experimental backend — supply assets via `referencedAssets` instead.
+   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    */
   export async function fromResource(
@@ -110,7 +114,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from raw bytes.
    * @param bytes - The raw bytes of the Rive (.riv) file
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the experimental backend — supply assets via `referencedAssets` instead.
+   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    */
   export async function fromBytes(
@@ -130,7 +134,7 @@ export namespace RiveFileFactory {
    * Creates a RiveFile instance from a source that can be either a resource ID or a URI object.
    * @param source - Either a number representing a resource ID or an object with a uri property
    * @param loadCdn - Whether to fetch CDN-referenced assets (default: true).
-   *   Ignored on the experimental backend — supply assets via `referencedAssets` instead.
+   *   Ignored on the new runtime — supply assets via `referencedAssets` instead.
    * @returns Promise that resolves to a RiveFile instance
    * @throws Error if the source is invalid or cannot be resolved
    * @example

--- a/src/core/RiveView.tsx
+++ b/src/core/RiveView.tsx
@@ -35,7 +35,7 @@ const defaultOnError = (error: RiveError) =>
  * @property {boolean} [autoPlay=true] - Whether to automatically start playing the state machine
  * @property {Alignment} [alignment] - How the Rive graphic should be aligned within its container
  * @property {Fit} [fit] - How the Rive graphic should fit within its container
- * @property {number | FrameRateRange} [frameRate] - Preferred frame rate for the render loop (experimental backends only)
+ * @property {number | FrameRateRange} [frameRate] - Preferred frame rate for the render loop (new runtimes only)
  * @property {Object} [style] - React Native style object for container customization
  * @property {(error: RiveError) => void} [onError] - Callback function that is called when an error occurs
  *

--- a/src/hooks/__tests__/useRiveProperty.test.ts
+++ b/src/hooks/__tests__/useRiveProperty.test.ts
@@ -31,7 +31,7 @@ describe('useRiveProperty', () => {
       addListener: jest.fn((callback: (value: string) => void) => {
         listener = callback;
         // Emit the current value immediately on subscribe, matching native behaviour:
-        // iOS legacy emits synchronously; experimental backend emits via valueStream.
+        // iOS legacy emits synchronously; new runtime emits via valueStream.
         callback(currentValue);
         return () => {
           listener = null;
@@ -125,8 +125,8 @@ describe('useRiveProperty', () => {
     expect(error?.message).toContain('nonexistent/path');
   });
 
-  it('should surface an error when getValueAsync rejects (experimental backend: unvalidated handle for a bad path)', async () => {
-    // The experimental backend returns a wrapper for any path — the bad path
+  it('should surface an error when getValueAsync rejects (new runtime: unvalidated handle for a bad path)', async () => {
+    // The new runtime returns a wrapper for any path — the bad path
     // is only reported when the command server is asked for the value.
     const rejectingProperty = {
       set: jest.fn(),

--- a/src/hooks/useRiveList.ts
+++ b/src/hooks/useRiveList.ts
@@ -61,7 +61,7 @@ export function useRiveList(
   }, [property]);
 
   // Re-read the length whenever the list changes (revision bumps) or the
-  // property itself changes. On the experimental backend a rejection here is
+  // property itself changes. On the new runtime a rejection here is
   // also how an invalid list path surfaces.
   useEffect(() => {
     if (!property) {
@@ -86,7 +86,7 @@ export function useRiveList(
     };
   }, [property, path, revision]);
 
-  // The experimental backend has no native list-change notifications
+  // The new runtime has no native list-change notifications
   // (addListener is a no-op there) — refresh after our own mutations so
   // `length` stays live on both backends.
   const afterMutation = useCallback(<T>(op: Promise<T>): Promise<T> => {

--- a/src/hooks/useRiveProperty.ts
+++ b/src/hooks/useRiveProperty.ts
@@ -53,7 +53,7 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
   }
 
   // Always start undefined — the listener delivers the current value as its first emission.
-  // (iOS experimental: via valueStream; iOS/Android legacy: emitted synchronously on subscribe)
+  // (new iOS runtime: via valueStream; iOS/Android legacy: emitted synchronously on subscribe)
   // This ensures consumers handle the loading state correctly on all backends.
   const [value, setValue] = useState<T | undefined>(undefined);
   const [error, setError] = useState<Error | null>(null);
@@ -80,7 +80,7 @@ export function useRiveProperty<P extends ViewModelProperty, T>(
 
     // Deliver the current value so the hook transitions from undefined → value
     // without waiting for a property change (legacy addListener does NOT emit
-    // on subscribe — only on changes). On the experimental backend the
+    // on subscribe — only on changes). On the new runtime the
     // accessor returns an unvalidated handle — the command server can only
     // report a bad path asynchronously — so a rejection here is also how
     // "property not found" surfaces as the hook's error.

--- a/src/hooks/useViewModelInstanceAsync.ts
+++ b/src/hooks/useViewModelInstanceAsync.ts
@@ -144,7 +144,7 @@ async function createInstanceAsync(
     } finally {
       // The intermediate ViewModel wrapper is hook-internal; disposing it
       // releases the native resources it owns (e.g. the artboard resolved
-      // for DefaultForArtboard sources on the experimental backend).
+      // for DefaultForArtboard sources on the new runtime).
       callDispose(viewModel);
     }
   }

--- a/src/specs/RiveFile.nitro.ts
+++ b/src/specs/RiveFile.nitro.ts
@@ -90,7 +90,7 @@ export interface RiveFile
    * Get all enums defined in this Rive file.
    * Useful for debugging and building dynamic UIs.
    *
-   * Backend note: implemented on the experimental (default) backend and on
+   * Backend note: implemented on the new (default) runtime and on
    * legacy Android; legacy iOS rejects (not supported there).
    */
   getEnums(): Promise<RiveEnumDefinition[]>;
@@ -101,7 +101,11 @@ export interface RiveFileFactory
     ios: 'swift';
     android: 'kotlin';
   }> {
-  /** Which backend is in use: "legacy" or "experimental" */
+  /**
+   * Which backend is in use. `'experimental'` identifies the new
+   * (CommandQueue-based) runtime — the string predates the "new runtime"
+   * naming and is kept for API stability.
+   */
   readonly backend: string;
   fromURL(
     url: string,

--- a/src/specs/RiveFile.nitro.ts
+++ b/src/specs/RiveFile.nitro.ts
@@ -101,7 +101,7 @@ export interface RiveFileFactory
     ios: 'swift';
     android: 'kotlin';
   }> {
-  /** @internal Which runtime is in use ("experimental" = the new CommandQueue-based one). For internal testing; removed in 0.6 with the legacy runtime. */
+  /** @internal Which runtime is in use ("experimental" = the new CommandQueue-based one). For internal testing; will be removed together with the legacy runtime in a future release. */
   readonly backend: string;
   fromURL(
     url: string,

--- a/src/specs/RiveFile.nitro.ts
+++ b/src/specs/RiveFile.nitro.ts
@@ -101,11 +101,7 @@ export interface RiveFileFactory
     ios: 'swift';
     android: 'kotlin';
   }> {
-  /**
-   * Which backend is in use. `'experimental'` identifies the new
-   * (CommandQueue-based) runtime — the string predates the "new runtime"
-   * naming and is kept for API stability.
-   */
+  /** @internal Which runtime is in use ("experimental" = the new CommandQueue-based one). For internal testing; removed in 0.6 with the legacy runtime. */
   readonly backend: string;
   fromURL(
     url: string,

--- a/src/specs/RiveView.nitro.ts
+++ b/src/specs/RiveView.nitro.ts
@@ -57,7 +57,7 @@ export interface RiveViewProps extends HybridViewProps {
    * screens). Capping limits frame production, not animation time — playback
    * still advances by the real elapsed time between frames.
    *
-   * Only supported on the experimental (default) backends; the legacy
+   * Only supported on the new (default) runtimes; the legacy
    * backends ignore it. Undefined = render at the display refresh rate.
    *
    * @see https://rive.app/docs/runtimes/apple/apple#frame-rate
@@ -67,7 +67,7 @@ export interface RiveViewProps extends HybridViewProps {
    * Exposes accessibility semantics authored in the Rive editor to the
    * platform screen reader (VoiceOver). Defaults to Semantics.Off.
    *
-   * Only supported on the experimental (default) iOS backend so far; ignored
+   * Only supported on the new (default) iOS runtime so far; ignored
    * elsewhere. Android support is pending the upstream rive-android runtime.
    *
    * @see https://rive.app/docs/runtimes/apple/semantics
@@ -102,7 +102,7 @@ export interface RiveViewMethods extends HybridViewMethods {
   pause(): Promise<void>;
   /**
    * Resets the Rive graphic to its initial state.
-   * @deprecated Not supported on the experimental backend (logs an error and
+   * @deprecated Not supported on the new runtime (logs an error and
    * does nothing).
    */
   reset(): Promise<void>;
@@ -114,7 +114,7 @@ export interface RiveViewMethods extends HybridViewMethods {
    * Adds an event listener to the Rive view
    * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
    *
-   * Throws on the experimental (default) backend — only the legacy backend
+   * Throws on the new (default) runtime — only the legacy backend
    * (USE_RIVE_LEGACY) implements it.
    * @param onEvent - The function to call when an event is triggered
    */
@@ -123,7 +123,7 @@ export interface RiveViewMethods extends HybridViewMethods {
    * Removes all event listeners from the Rive view
    * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
    *
-   * Throws on the experimental (default) backend — only the legacy backend
+   * Throws on the new (default) runtime — only the legacy backend
    * (USE_RIVE_LEGACY) implements it.
    */
   removeEventListeners(): void;
@@ -131,7 +131,7 @@ export interface RiveViewMethods extends HybridViewMethods {
    * Sets a number state machine input on the Rive view
    * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
    *
-   * Throws on the experimental (default) backend — only the legacy backend
+   * Throws on the new (default) runtime — only the legacy backend
    * (USE_RIVE_LEGACY) implements it.
    * @param name - The name of the state machine input
    * @param value - The value to set the state machine input to
@@ -142,7 +142,7 @@ export interface RiveViewMethods extends HybridViewMethods {
    * Gets a number state machine input from the Rive view
    * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
    *
-   * Throws on the experimental (default) backend — only the legacy backend
+   * Throws on the new (default) runtime — only the legacy backend
    * (USE_RIVE_LEGACY) implements it.
    * @param name - The name of the state machine input
    * @param path - The optional path to the state machine input on a nested artboard
@@ -153,7 +153,7 @@ export interface RiveViewMethods extends HybridViewMethods {
    * Sets a boolean state machine input on the Rive view
    * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
    *
-   * Throws on the experimental (default) backend — only the legacy backend
+   * Throws on the new (default) runtime — only the legacy backend
    * (USE_RIVE_LEGACY) implements it.
    * @param name - The name of the state machine input
    * @param value - The value to set the state machine input to
@@ -164,7 +164,7 @@ export interface RiveViewMethods extends HybridViewMethods {
    * Gets a boolean state machine input from the Rive view
    * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
    *
-   * Throws on the experimental (default) backend — only the legacy backend
+   * Throws on the new (default) runtime — only the legacy backend
    * (USE_RIVE_LEGACY) implements it.
    * @param name - The name of the state machine input
    * @param path - The optional path to the state machine input on a nested artboard
@@ -175,7 +175,7 @@ export interface RiveViewMethods extends HybridViewMethods {
    * Triggers a trigger state machine input on the Rive view
    * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
    *
-   * Throws on the experimental (default) backend — only the legacy backend
+   * Throws on the new (default) runtime — only the legacy backend
    * (USE_RIVE_LEGACY) implements it.
    * @param name - The name of the state machine input
    * @param path - The optional path to the state machine input on a nested artboard
@@ -185,7 +185,7 @@ export interface RiveViewMethods extends HybridViewMethods {
    * Sets the text run value on the Rive view
    * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
    *
-   * Throws on the experimental (default) backend — only the legacy backend
+   * Throws on the new (default) runtime — only the legacy backend
    * (USE_RIVE_LEGACY) implements it.
    * @param name - The name of the text run
    * @param value - The text to set the text run value to
@@ -196,7 +196,7 @@ export interface RiveViewMethods extends HybridViewMethods {
    * Gets the text run value from the Rive view
    * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
    *
-   * Throws on the experimental (default) backend — only the legacy backend
+   * Throws on the new (default) runtime — only the legacy backend
    * (USE_RIVE_LEGACY) implements it.
    * @param name - The name of the text run
    * @param path - The optional path to the text run on a nested artboard

--- a/src/specs/RiveView.nitro.ts
+++ b/src/specs/RiveView.nitro.ts
@@ -112,27 +112,21 @@ export interface RiveViewMethods extends HybridViewMethods {
 
   /**
    * Adds an event listener to the Rive view
-   * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
-   *
-   * Throws on the new (default) runtime — only the legacy backend
-   * (USE_RIVE_LEGACY) implements it.
+   * @deprecated No longer supported — throws. Use data binding instead:
+   * https://rive.app/docs/runtimes/data-binding
    * @param onEvent - The function to call when an event is triggered
    */
   onEventListener(onEvent: (event: UnifiedRiveEvent) => void): void;
   /**
    * Removes all event listeners from the Rive view
-   * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
-   *
-   * Throws on the new (default) runtime — only the legacy backend
-   * (USE_RIVE_LEGACY) implements it.
+   * @deprecated No longer supported — throws. Use data binding instead:
+   * https://rive.app/docs/runtimes/data-binding
    */
   removeEventListeners(): void;
   /**
    * Sets a number state machine input on the Rive view
-   * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
-   *
-   * Throws on the new (default) runtime — only the legacy backend
-   * (USE_RIVE_LEGACY) implements it.
+   * @deprecated No longer supported — throws. Use data binding instead:
+   * https://rive.app/docs/runtimes/data-binding
    * @param name - The name of the state machine input
    * @param value - The value to set the state machine input to
    * @param path - The optional path to the state machine input on a nested artboard
@@ -140,10 +134,8 @@ export interface RiveViewMethods extends HybridViewMethods {
   setNumberInputValue(name: string, value: number, path?: string): void;
   /**
    * Gets a number state machine input from the Rive view
-   * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
-   *
-   * Throws on the new (default) runtime — only the legacy backend
-   * (USE_RIVE_LEGACY) implements it.
+   * @deprecated No longer supported — throws. Use data binding instead:
+   * https://rive.app/docs/runtimes/data-binding
    * @param name - The name of the state machine input
    * @param path - The optional path to the state machine input on a nested artboard
    * @returns The value of the state machine input
@@ -151,10 +143,8 @@ export interface RiveViewMethods extends HybridViewMethods {
   getNumberInputValue(name: string, path?: string): number;
   /**
    * Sets a boolean state machine input on the Rive view
-   * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
-   *
-   * Throws on the new (default) runtime — only the legacy backend
-   * (USE_RIVE_LEGACY) implements it.
+   * @deprecated No longer supported — throws. Use data binding instead:
+   * https://rive.app/docs/runtimes/data-binding
    * @param name - The name of the state machine input
    * @param value - The value to set the state machine input to
    * @param path - The optional path to the state machine input on a nested artboard
@@ -162,10 +152,8 @@ export interface RiveViewMethods extends HybridViewMethods {
   setBooleanInputValue(name: string, value: boolean, path?: string): void;
   /**
    * Gets a boolean state machine input from the Rive view
-   * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
-   *
-   * Throws on the new (default) runtime — only the legacy backend
-   * (USE_RIVE_LEGACY) implements it.
+   * @deprecated No longer supported — throws. Use data binding instead:
+   * https://rive.app/docs/runtimes/data-binding
    * @param name - The name of the state machine input
    * @param path - The optional path to the state machine input on a nested artboard
    * @returns The value of the state machine input
@@ -173,20 +161,16 @@ export interface RiveViewMethods extends HybridViewMethods {
   getBooleanInputValue(name: string, path?: string): boolean;
   /**
    * Triggers a trigger state machine input on the Rive view
-   * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
-   *
-   * Throws on the new (default) runtime — only the legacy backend
-   * (USE_RIVE_LEGACY) implements it.
+   * @deprecated No longer supported — throws. Use data binding instead:
+   * https://rive.app/docs/runtimes/data-binding
    * @param name - The name of the state machine input
    * @param path - The optional path to the state machine input on a nested artboard
    */
   triggerInput(name: string, path?: string): void;
   /**
    * Sets the text run value on the Rive view
-   * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
-   *
-   * Throws on the new (default) runtime — only the legacy backend
-   * (USE_RIVE_LEGACY) implements it.
+   * @deprecated No longer supported — throws. Use data binding instead:
+   * https://rive.app/docs/runtimes/data-binding
    * @param name - The name of the text run
    * @param value - The text to set the text run value to
    * @param path - The optional path to the text run on a nested artboard
@@ -194,10 +178,8 @@ export interface RiveViewMethods extends HybridViewMethods {
   setTextRunValue(name: string, value: string, path?: string): void;
   /**
    * Gets the text run value from the Rive view
-   * @deprecated Use data binding instead. See https://rive.app/docs/runtimes/data-binding
-   *
-   * Throws on the new (default) runtime — only the legacy backend
-   * (USE_RIVE_LEGACY) implements it.
+   * @deprecated No longer supported — throws. Use data binding instead:
+   * https://rive.app/docs/runtimes/data-binding
    * @param name - The name of the text run
    * @param path - The optional path to the text run on a nested artboard
    * @returns The text run value

--- a/src/specs/ViewModel.nitro.ts
+++ b/src/specs/ViewModel.nitro.ts
@@ -39,11 +39,7 @@ export interface ViewModel
   readonly instanceCount: number;
   /** The name of the view model */
   readonly modelName: string;
-  /**
-   * All properties defined on this view model.
-   *
-   * Backend note: rejects on the legacy backend (new runtime only).
-   */
+  /** All properties defined on this view model */
   getPropertiesAsync(): Promise<ViewModelPropertyInfo[]>;
   /** The number of properties in the view model */
   getPropertyCountAsync(): Promise<number>;
@@ -81,9 +77,8 @@ export interface ViewModelInstance
   /**
    * The name of the view model instance.
    *
-   * New runtime: the runtime does not expose instance names yet
-   * (verified through rive-android 11.7.2 / rive-ios 6.21.1; SDK support has been requested),
-   * so this is only populated for instances created via
+   * The underlying Rive SDKs do not expose instance names yet (support has
+   * been requested), so this is only populated for instances created via
    * `createInstanceByName` / `createInstanceByIndex` — default, blank,
    * nested, and view-obtained instances report `""` until the SDKs expose it.
    */
@@ -91,23 +86,20 @@ export interface ViewModelInstance
   /**
    * All properties available on this view model instance.
    *
-   * Backend note: rejects on the legacy backend, and on the new runtime
-   * for instances whose ViewModel metadata is unknown (nested paths,
-   * list items, view-obtained instances) — query the ViewModel instead.
+   * Rejects for instances whose ViewModel metadata is unknown (nested
+   * paths, list items, view-obtained instances) — query the
+   * {@link ViewModel} it was created from instead.
    */
   getPropertiesAsync(): Promise<ViewModelPropertyInfo[]>;
   /**
    * Get a number property from the view model instance at the given path.
    *
-   * Backend note (applies to all property accessors below): the legacy
-   * backend validates the path synchronously and returns `undefined` when it
-   * does not exist. The new runtime cannot — property lookup
-   * happens on the async command server — so it returns an unvalidated
-   * handle for any path, and a bad path surfaces when the property is used:
-   * `getValueAsync()` rejects, listeners never fire, and the `useRive*`
-   * hooks report it via their `error` result. Do not rely on a falsy return
-   * to detect typos on the new runtime; check
-   * `getPropertiesAsync()` or handle the `getValueAsync()` rejection.
+   * Note (applies to all property accessors below): the returned handle is
+   * not validated — property lookup happens on the async runtime — so a bad
+   * path surfaces when the property is used: `getValueAsync()` rejects,
+   * listeners never fire, and the `useRive*` hooks report it via their
+   * `error` result. To detect typos, check `getPropertiesAsync()` or handle
+   * the `getValueAsync()` rejection.
    */
   numberProperty(path: string): ViewModelNumberProperty | undefined;
 

--- a/src/specs/ViewModel.nitro.ts
+++ b/src/specs/ViewModel.nitro.ts
@@ -42,7 +42,7 @@ export interface ViewModel
   /**
    * All properties defined on this view model.
    *
-   * Backend note: rejects on the legacy backend (experimental only).
+   * Backend note: rejects on the legacy backend (new runtime only).
    */
   getPropertiesAsync(): Promise<ViewModelPropertyInfo[]>;
   /** The number of properties in the view model */
@@ -81,8 +81,8 @@ export interface ViewModelInstance
   /**
    * The name of the view model instance.
    *
-   * Experimental backend: the runtime does not expose instance names yet
-   * (verified through rive-android 11.7.0; SDK support has been requested),
+   * New runtime: the runtime does not expose instance names yet
+   * (verified through rive-android 11.7.2 / rive-ios 6.21.1; SDK support has been requested),
    * so this is only populated for instances created via
    * `createInstanceByName` / `createInstanceByIndex` — default, blank,
    * nested, and view-obtained instances report `""` until the SDKs expose it.
@@ -91,8 +91,8 @@ export interface ViewModelInstance
   /**
    * All properties available on this view model instance.
    *
-   * Backend note: rejects on the legacy backend, and on the experimental
-   * backend for instances whose ViewModel metadata is unknown (nested paths,
+   * Backend note: rejects on the legacy backend, and on the new runtime
+   * for instances whose ViewModel metadata is unknown (nested paths,
    * list items, view-obtained instances) — query the ViewModel instead.
    */
   getPropertiesAsync(): Promise<ViewModelPropertyInfo[]>;
@@ -101,12 +101,12 @@ export interface ViewModelInstance
    *
    * Backend note (applies to all property accessors below): the legacy
    * backend validates the path synchronously and returns `undefined` when it
-   * does not exist. The experimental backend cannot — property lookup
+   * does not exist. The new runtime cannot — property lookup
    * happens on the async command server — so it returns an unvalidated
    * handle for any path, and a bad path surfaces when the property is used:
    * `getValueAsync()` rejects, listeners never fire, and the `useRive*`
    * hooks report it via their `error` result. Do not rely on a falsy return
-   * to detect typos on the experimental backend; check
+   * to detect typos on the new runtime; check
    * `getPropertiesAsync()` or handle the `getValueAsync()` rejection.
    */
   numberProperty(path: string): ViewModelNumberProperty | undefined;


### PR DESCRIPTION
Aligns our wording with Rive's official docs, which call the CommandQueue-based runtimes the "New Runtime" (Apple) / "New Compose API" (Android) and the previous ones "legacy" — "experimental" was our own term and is now off-message.

1. Docs and spec JSDoc use the new/legacy vocabulary; user-facing error messages now say e.g. "not supported by the new runtime — use data binding".
2. API docs describe plain runtime behavior instead of comparing backends: the backend switch is for internal behavior-comparison testing only, so `getBackend()` is documented `@internal` (its `'experimental' | 'legacy'` return value is unchanged), the `updateReferencedAssets` warning no longer suggests switching to the legacy backend, and backend talk lives only in the contributor guide (`docs/runtime-backends.md`).
3. Adds `docs/migrating-to-0.5.md`: migrate to the async APIs on 0.4.x (full deprecated→replacement table), try the 0.5 beta, 0.5 stable keeps runtime deprecation warnings, and removal of the deprecated APIs is planned for 0.6.
4. The legacy runtime itself carries no removal-version commitment — "a future release once the new runtime has fully proven out (not necessarily 0.6)" — so the fallback stays available through a potentially breaking 0.6.

No behavior change; the only code deltas are two warning-message strings.