### PR TITLE
feat: ship rive-gen-types as a bin

### DIFF
--- a/cli/rive-gen-types.js
+++ b/cli/rive-gen-types.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+// Launcher for the compiled generator (built by `yarn build:cli`).
+require('../lib/cli/rive-gen-types.cjs')
+  .runCli()
+  .catch((err) => {
+    process.stderr.write(`${err && err.message ? err.message : err}\n`);
+    process.exit(1);
+  });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "cli",
     "src",
     "lib",
     "android",
@@ -38,7 +39,7 @@
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
-    "prepare": "npx react-native-builder-bob@^0.40.0 build",
+    "prepare": "npx react-native-builder-bob@^0.40.0 build && yarn build:cli",
     "nitrogen": "nitrogen && npx tsx scripts/nitrogen-postprocess.ts",
     "rive-gen-types": "bun scripts/rive-gen-types.ts",
     "release": "release-it",
@@ -50,7 +51,8 @@
     "lint:fix:kotlin": "./scripts/lint-fix-kotlin.sh",
     "lint:native": "yarn lint:swift && yarn lint:kotlin",
     "typetest": "tsd --typings src/index.tsx",
-    "test:scripts": "cd scripts/__tests__ && bun test --no-parallel"
+    "test:scripts": "cd scripts/__tests__ && bun test --no-parallel",
+    "build:cli": "esbuild scripts/rive-gen-types.ts --outfile=lib/cli/rive-gen-types.cjs --format=cjs --platform=node --target=node20 --log-override:empty-import-meta=silent"
   },
   "keywords": [
     "react-native",
@@ -92,6 +94,7 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "commitlint": "^19.6.1",
     "del-cli": "^5.1.0",
+    "esbuild": "^0.27.7",
     "eslint": "^9.22.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-jest": "^29.1.0",
@@ -110,6 +113,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
+    "@rive-app/canvas": "^2.39.0",
     "react": "*",
     "react-native": "*",
     "react-native-nitro-modules": ">=0.35.10 <0.36"
@@ -228,5 +232,13 @@
     "browserslist": "^4.24.4",
     "@react-native-harness/runtime@1.4.0-rc.1": "patch:@react-native-harness/runtime@npm%3A1.4.0-rc.1#./.yarn/patches/@react-native-harness-runtime-npm-1.4.0-rc.1-5f3d78d6f0.patch",
     "@react-native-harness/bundler-metro@1.4.0-rc.1": "patch:@react-native-harness/bundler-metro@npm%3A1.4.0-rc.1#./.yarn/patches/@react-native-harness-bundler-metro-npm-1.4.0-rc.1-748c6eda8c.patch"
+  },
+  "bin": {
+    "rive-gen-types": "cli/rive-gen-types.js"
+  },
+  "peerDependenciesMeta": {
+    "@rive-app/canvas": {
+      "optional": true
+    }
   }
 }

--- a/scripts/rive-gen-types.ts
+++ b/scripts/rive-gen-types.ts
@@ -25,10 +25,6 @@ import {
 } from 'fs';
 import { dirname, resolve, basename, extname } from 'path';
 import { pathToFileURL } from 'url';
-// Default-import + destructure: @rive-app/canvas is CJS, and Node's ESM
-// loader cannot statically see its named exports (bun's interop can).
-import riveCanvas from '@rive-app/canvas';
-const { RuntimeLoader } = riveCanvas;
 
 // Called from main() so that importing this module (for unit-testing the
 // exported emit helpers) has no global side effects.
@@ -57,7 +53,24 @@ let runtimeReady: Promise<any> | null = null;
 
 async function getRuntime(): Promise<any> {
   if (!runtimeReady) {
-    runtimeReady = RuntimeLoader.awaitInstance();
+    runtimeReady = (async () => {
+      let riveCanvas: any;
+      try {
+        // Dynamic import: when shipped as a bin, @rive-app/canvas is an
+        // optional (dev-time only) peer — users who run codegen install it,
+        // everyone else never downloads the wasm.
+        riveCanvas = await import('@rive-app/canvas');
+      } catch {
+        throw new Error(
+          "rive-gen-types needs '@rive-app/canvas' to inspect .riv files.\n" +
+            'Install it as a devDependency:\n' +
+            '  yarn add -D @rive-app/canvas   (or npm install -D @rive-app/canvas)'
+        );
+      }
+      // CJS/ESM interop: named exports may only be visible on .default.
+      const mod = riveCanvas.default ?? riveCanvas;
+      return mod.RuntimeLoader.awaitInstance();
+    })();
   }
   return runtimeReady;
 }
@@ -403,6 +416,11 @@ const isMain =
   import.meta.main ||
   (process.argv[1] != null &&
     import.meta.url === pathToFileURL(process.argv[1]).href);
+
+/** Entry point for the published `rive-gen-types` bin (see cli/). */
+export function runCli(): Promise<void> {
+  return main();
+}
 
 if (isMain) {
   main().catch((err: Error) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7032,6 +7032,7 @@ __metadata:
     babel-plugin-react-compiler: ^1.0.0
     commitlint: ^19.6.1
     del-cli: ^5.1.0
+    esbuild: ^0.27.7
     eslint: ^9.22.0
     eslint-config-prettier: ^10.1.1
     eslint-plugin-jest: ^29.1.0
@@ -7049,9 +7050,15 @@ __metadata:
     turbo: ^1.10.7
     typescript: ^5.2.2
   peerDependencies:
+    "@rive-app/canvas": ^2.39.0
     react: "*"
     react-native: "*"
     react-native-nitro-modules: ">=0.35.10 <0.36"
+  peerDependenciesMeta:
+    "@rive-app/canvas":
+      optional: true
+  bin:
+    rive-gen-types: cli/rive-gen-types.js
   languageName: unknown
   linkType: soft
 
@@ -11130,7 +11137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.27.0":
+"esbuild@npm:^0.27.0, esbuild@npm:^0.27.7":
   version: 0.27.7
   resolution: "esbuild@npm:0.27.7"
   dependencies:


### PR DESCRIPTION
Stacked on #352. Implements the packaging decision from the review discussion: the schema generator ships inside @rive-app/react-native as a `bin`, with `@rive-app/canvas` as an optional (dev-time) peer dependency.

Usage in an app:

1. `yarn add -D @rive-app/canvas` (one-time; the CLI prints this exact instruction if missing)
2. `npx rive-gen-types assets/rive/my.riv` (or `--all assets/rive`) — writes `my.riv.d.ts` next to the asset

The published tool is plain compiled CommonJS (esbuild, target node20, built during `prepare` into `lib/cli/`, launched via a committed `cli/rive-gen-types.js` wrapper) — no Bun, no TypeScript runtime, no wasm download for users who don't generate types.

Verified end to end with `npm pack` + install into a fresh project: missing-canvas error path (clear hint, exit 1) and successful generation producing the expected `.riv.d.ts`.

Longer-term home (separate `@rive-app/ts-schema-generator` package or the future Rive CLI) intentionally stays open — migrating is a deprecation notice in a future release.