### PR TITLE
fix(ios): blank RiveView after Fabric recreates the component view (react-freeze) — props skipped by consumed isDirty flags

### DIFF
--- a/nitrogen/generated/ios/c++/views/HybridRiveViewComponent.mm
+++ b/nitrogen/generated/ios/c++/views/HybridRiveViewComponent.mm
@@ -30,6 +30,15 @@ using namespace margelo::nitro::rive::views;
 
 @implementation HybridRiveViewComponent {
   std::shared_ptr<HybridRiveViewSpecSwift> _hybridView;
+  // Fabric can recreate this component view from an unchanged ShadowNode
+  // (e.g. react-freeze / Suspense re-inserting a previously hidden screen).
+  // The cached props' isDirty flags were already consumed by the previous
+  // view instance (they live on the shared Props object and are mutated on
+  // first apply), so updateProps would apply nothing and the fresh
+  // HybridRiveView would stay unconfigured: no file, no artboard, and a
+  // hybridRef that never fires (JS keeps a ref to the dead old hybrid).
+  // Force-apply every prop on this instance's first updateProps.
+  BOOL _didApplyInitialProps;
 }
 
 + (void) load {
@@ -69,61 +78,66 @@ using namespace margelo::nitro::rive::views;
   auto& newViewProps = const_cast<HybridRiveViewProps&>(newViewPropsConst);
   RNRive::HybridRiveViewSpec_cxx& swiftPart = _hybridView->getSwiftPart();
 
+  // Force-apply all props the first time this view instance updates (see
+  // _didApplyInitialProps above).
+  BOOL force = !_didApplyInitialProps;
+  _didApplyInitialProps = YES;
+
   // 2. Update each prop individually
   swiftPart.beforeUpdate();
 
   // artboardName: optional
-  if (newViewProps.artboardName.isDirty) {
+  if (force || newViewProps.artboardName.isDirty) {
     swiftPart.setArtboardName(newViewProps.artboardName.value);
     newViewProps.artboardName.isDirty = false;
   }
   // stateMachineName: optional
-  if (newViewProps.stateMachineName.isDirty) {
+  if (force || newViewProps.stateMachineName.isDirty) {
     swiftPart.setStateMachineName(newViewProps.stateMachineName.value);
     newViewProps.stateMachineName.isDirty = false;
   }
   // autoPlay: optional
-  if (newViewProps.autoPlay.isDirty) {
+  if (force || newViewProps.autoPlay.isDirty) {
     swiftPart.setAutoPlay(newViewProps.autoPlay.value);
     newViewProps.autoPlay.isDirty = false;
   }
   // file: hybrid-object
-  if (newViewProps.file.isDirty) {
+  if (force || newViewProps.file.isDirty) {
     swiftPart.setFile(newViewProps.file.value);
     newViewProps.file.isDirty = false;
   }
   // alignment: optional
-  if (newViewProps.alignment.isDirty) {
+  if (force || newViewProps.alignment.isDirty) {
     swiftPart.setAlignment(newViewProps.alignment.value);
     newViewProps.alignment.isDirty = false;
   }
   // fit: optional
-  if (newViewProps.fit.isDirty) {
+  if (force || newViewProps.fit.isDirty) {
     swiftPart.setFit(newViewProps.fit.value);
     newViewProps.fit.isDirty = false;
   }
   // layoutScaleFactor: optional
-  if (newViewProps.layoutScaleFactor.isDirty) {
+  if (force || newViewProps.layoutScaleFactor.isDirty) {
     swiftPart.setLayoutScaleFactor(newViewProps.layoutScaleFactor.value);
     newViewProps.layoutScaleFactor.isDirty = false;
   }
   // frameRate: optional
-  if (newViewProps.frameRate.isDirty) {
+  if (force || newViewProps.frameRate.isDirty) {
     swiftPart.setFrameRate(newViewProps.frameRate.value);
     newViewProps.frameRate.isDirty = false;
   }
   // semantics: optional
-  if (newViewProps.semantics.isDirty) {
+  if (force || newViewProps.semantics.isDirty) {
     swiftPart.setSemantics(newViewProps.semantics.value);
     newViewProps.semantics.isDirty = false;
   }
   // dataBind: optional
-  if (newViewProps.dataBind.isDirty) {
+  if (force || newViewProps.dataBind.isDirty) {
     swiftPart.setDataBind(newViewProps.dataBind.value);
     newViewProps.dataBind.isDirty = false;
   }
   // onError: function
-  if (newViewProps.onError.isDirty) {
+  if (force || newViewProps.onError.isDirty) {
     swiftPart.setOnError(newViewProps.onError.value);
     newViewProps.onError.isDirty = false;
   }
@@ -131,7 +145,7 @@ using namespace margelo::nitro::rive::views;
   swiftPart.afterUpdate();
 
   // 3. Update hybridRef if it changed
-  if (newViewProps.hybridRef.isDirty) {
+  if (force || newViewProps.hybridRef.isDirty) {
     // hybridRef changed - call it with new this
     const auto& maybeFunc = newViewProps.hybridRef.value;
     if (maybeFunc.has_value()) {

--- a/scripts/nitrogen-postprocess.ts
+++ b/scripts/nitrogen-postprocess.ts
@@ -61,13 +61,9 @@ function acceptNullForOptionalProps() {
   );
 
   if (content === updated) {
-    if (content.includes('value.isNull()')) {
-      console.log('HybridRiveViewComponent.cpp already accepts null props');
-    } else {
-      console.warn(
-        'No optional CachedProp parse sites found in HybridRiveViewComponent.cpp — nitrogen output may have changed shape'
-      );
-    }
+    console.warn(
+      'No optional CachedProp parse sites found in HybridRiveViewComponent.cpp — nitrogen output may have changed shape'
+    );
     return;
   }
 

--- a/scripts/nitrogen-postprocess.ts
+++ b/scripts/nitrogen-postprocess.ts
@@ -10,6 +10,10 @@ const COMPONENT_FILE = join(
   ROOT,
   'nitrogen/generated/shared/c++/views/HybridRiveViewComponent.cpp'
 );
+const IOS_COMPONENT_FILE = join(
+  ROOT,
+  'nitrogen/generated/ios/c++/views/HybridRiveViewComponent.mm'
+);
 
 function makeHybridRiveViewManagerOpen() {
   if (!existsSync(MANAGER_FILE)) {
@@ -44,6 +48,10 @@ function acceptNullForOptionalProps() {
   }
 
   const content = readFileSync(COMPONENT_FILE, 'utf-8');
+  if (content.includes('value.isNull()')) {
+    console.log('HybridRiveViewComponent.cpp already accepts null props');
+    return;
+  }
   const pattern =
     /^( *)return (CachedProp<std::optional<.+>>)::fromRawValue\(\*runtime, value, (sourceProps\.\w+)\);$/gm;
   const updated = content.replace(
@@ -69,5 +77,74 @@ function acceptNullForOptionalProps() {
   );
 }
 
+// Fabric can recreate the iOS component view from an unchanged ShadowNode
+// (e.g. react-freeze / Suspense re-inserting a previously hidden screen), but
+// the cached props' isDirty flags were already consumed by the previous view
+// instance (they live on the shared Props object and are mutated on first
+// apply), so updateProps would apply nothing and the fresh view would stay
+// unconfigured: no file, no artboard, and a hybridRef that never fires.
+// Force-apply every prop on a view instance's first updateProps.
+// Fixed upstream in nitro 0.37 (props are diffed against oldProps instead of
+// mutating shared isDirty state) — remove on the next nitro upgrade:
+// https://github.com/mrousavy/nitro/pull/1506
+const IVAR_BLOCK = `  // Fabric can recreate this component view from an unchanged ShadowNode
+  // (e.g. react-freeze / Suspense re-inserting a previously hidden screen).
+  // The cached props' isDirty flags were already consumed by the previous
+  // view instance (they live on the shared Props object and are mutated on
+  // first apply), so updateProps would apply nothing and the fresh
+  // HybridRiveView would stay unconfigured: no file, no artboard, and a
+  // hybridRef that never fires (JS keeps a ref to the dead old hybrid).
+  // Force-apply every prop on this instance's first updateProps.
+  BOOL _didApplyInitialProps;
+`;
+
+const FORCE_BLOCK = `
+  // Force-apply all props the first time this view instance updates (see
+  // _didApplyInitialProps above).
+  BOOL force = !_didApplyInitialProps;
+  _didApplyInitialProps = YES;
+`;
+
+function forceApplyPropsOnFirstUpdate() {
+  if (!existsSync(IOS_COMPONENT_FILE)) {
+    console.warn('HybridRiveViewComponent.mm not found, skipping');
+    return;
+  }
+
+  const content = readFileSync(IOS_COMPONENT_FILE, 'utf-8');
+  if (content.includes('_didApplyInitialProps')) {
+    console.log(
+      'HybridRiveViewComponent.mm already force-applies initial props'
+    );
+    return;
+  }
+
+  const ivarAnchor =
+    '  std::shared_ptr<HybridRiveViewSpecSwift> _hybridView;\n';
+  const updateAnchor = '\n  // 2. Update each prop individually\n';
+  const dirtyPattern = /if \(newViewProps\.(\w+)\.isDirty\)/g;
+  if (
+    !content.includes(ivarAnchor) ||
+    !content.includes(updateAnchor) ||
+    !dirtyPattern.test(content)
+  ) {
+    console.warn(
+      'Anchors for the force-apply patch not found in HybridRiveViewComponent.mm — nitrogen output may have changed shape'
+    );
+    return;
+  }
+
+  const updated = content
+    .replace(ivarAnchor, `${ivarAnchor}${IVAR_BLOCK}`)
+    .replace(updateAnchor, `${FORCE_BLOCK}${updateAnchor}`)
+    .replace(dirtyPattern, 'if (force || newViewProps.$1.isDirty)');
+
+  writeFileSync(IOS_COMPONENT_FILE, updated);
+  console.log(
+    'Patched HybridRiveViewComponent.mm to force-apply props on first update'
+  );
+}
+
 makeHybridRiveViewManagerOpen();
 acceptNullForOptionalProps();
+forceApplyPropsOnFirstUpdate();


### PR DESCRIPTION
## Symptom

On iOS (new architecture), a `RiveView` renders **permanently blank** after navigating away from its screen and coming back, when the app uses `react-native-screens` with `enableFreeze(true)` (react-freeze / Suspense). The native view is laid out (background color, size all correct) but nothing is ever drawn, and `play()` / `playIfNeeded()` on the ref silently do nothing. Android is unaffected.

## Root cause

When a screen is frozen, Fabric **deletes** its native views; on return it **recreates** them from the same, unchanged ShadowNodes — calling `updateProps:oldProps:` on the brand-new component view with the **same cached `Props` object** as before.

The nitrogen-generated `HybridRiveViewComponent.mm` guards every prop with `isDirty` and, after applying it, mutates the shared props object (`newViewProps.file.isDirty = false;` via `const_cast`). Those flags were already consumed by the *previous* view instance, so on recreation `updateProps` applies **nothing**:

- the fresh `HybridRiveView` keeps its default empty `HybridRiveFile`, so `afterUpdate()` bails at `guard let file = hybridFile.riveFile else { return }` — `configure()` never runs, no `RiveView` subview is ever created (we confirmed with a view-hierarchy inspector: the recreated `RiveReactNativeView` has zero children);
- `hybridRef` never re-fires, so JS still holds the ref to the dead old hybrid — which is why `play()` resolves fine but does nothing (`baseViewModel?.play()` on nil).

Nothing ever marks the props dirty again unless the JS `file` object changes identity, so the view stays blank forever.

This is the mirror image of mrousavy/nitro#1050: there, a recycled view keeps the old props; here, a recreated view gets no props at all. Reproduced on `@rive-app/react-native@0.4.19`; the generated code is identical on `main` and in `0.5.0-beta.1`.

## Fix

Track `_didApplyInitialProps` on the component view and force-apply every prop on the **first** `updateProps` of each view instance, keeping the `isDirty` fast path for all subsequent updates. First-ever mounts are unaffected (all flags are dirty there anyway); recreated views now get their full configuration and `hybridRef` fires with the new hybrid.

We've been running this as a patch in our app (large health-insurance app, several Rive scenes behind frozen tab/stack screens) and it fixes the blank-view repro deterministically.

## Note on the generated file

I'm aware this file is nitrogen-generated (`DO NOT MODIFY`) — the durable fix likely belongs in nitrogen's view-component template (and would then cover `frameRate`/`semantics`/`onStop` and any future props automatically, as this PR's `force ||` does). Opening this here since the generated sources are committed to this repo and ship in the npm package; happy to close in favor of an upstream nitrogen fix if you prefer to route it there.

## Repro

1. RN app with new architecture + `react-native-screens`, `enableFreeze(true)`
2. Screen A renders a `<RiveView>`; push any screen B on top (freeze unmounts A's native views)
3. Go back to A → the recreated `RiveView` is blank; `play()` no-ops; only a `file` identity change revives it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
