### PR TITLE
fix: bump rive-android to 11.9.1 and rive-ios to 6.23.1

### DIFF
--- a/android/src/new/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/new/java/com/rive/RiveReactNativeView.kt
@@ -317,6 +317,9 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
     settled = false
     settledJob?.cancel()
     settledJob = viewScope.launch {
+      // Deprecated in rive-android >= 11.8 (removal planned for 12.0), kept as a
+      // compatibility shim. Revisit when 12.0 defines the long-term settling surface.
+      @Suppress("DEPRECATION")
       worker.settledFlow.collect { settledHandle ->
         if (settledHandle == handle && !settled) {
           settled = true

--- a/ios/new/RiveRuntimeLogger.swift
+++ b/ios/new/RiveRuntimeLogger.swift
@@ -58,7 +58,7 @@ final class RiveRuntimeLogger: RiveRuntime.RiveLog.Logger, @unchecked Sendable {
         // first frame(s) have no drawable yet; the SDK logs that transient
         // condition at error level, which LogBox turns into a red screen in dev.
         // Rendering recovers on the next tick, so forward it as debug instead.
-        // https://github.com/rive-app/rive-ios/blob/6.21.1/Source/Concurrency/View/RiveUIView.swift#L449-L454
+        // https://github.com/rive-app/rive-ios/blob/6.23.1/Source/Concurrency/View/RiveUIView.swift#L448-L453
         if case .view = tag, text == "Draw failed: missing drawable" {
             RiveLog.d(name, "\(text)\(suffix)")
             return

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
   "runtimeVersions": {
-    "ios": "6.21.1",
-    "android": "11.7.2"
+    "ios": "6.23.1",
+    "android": "11.9.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Bumps the pinned native runtimes to the latest releases: rive-android 11.7.2 → 11.9.1 and rive-ios 6.21.1 → 6.23.1.

On Android, 11.8.0 removed `CommandQueue.settledFlow` and 11.9.0 restored it as a deprecated shim (removal planned for 12.0), so the settling observer behind `onStop` keeps working under a `@Suppress("DEPRECATION")`. 11.9.0 also tightens resource lifetime contracts — operations on closed resources now throw `RiveResourceClosedException` synchronously instead of failing generically — and adds clearing of image properties. On iOS, 6.22.0 adds view-model instance names, 6.23.0 fixes data bindings in some state-machine files plus Metal validation errors when rendering images, and 6.23.1 makes runtime assertions debug-only.

11.9.x also deprecates a batch of APIs the new Android backend still calls (`fromFile` → `create`, `createStateMachineByName` → `createStateMachineByNameConfirmed`), all slated for removal in 12.0. Those are compile warnings only; migrating them is left as a follow-up.

Verified locally: harness suites pass on both backends on both platforms (iOS 28/28 suites, 208 tests; Android new backend 28/28, 208 tests; Android legacy 28/28 after retrying two suites that flaked on the 1000 ms mount timeout, the same flake CI retries for). iOS example builds clean against 6.23.1 with both the new and legacy podspec paths, and jest, typecheck, eslint and ktlint are clean.