### PR TITLE
fix: bump rive-android to 11.9.1 and rive-ios to 6.23.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,12 @@
 name: Release Please
 
+# This copy lives on the release-v0.4 maintenance branch, which ships the stable
+# 0.4.x line to the npm `latest` tag. `main` runs its own copy for the 0.5.0-beta
+# prereleases; a push only ever triggers the workflow file on the branch pushed.
 on:
   push:
     branches:
-      - main
+      - release-v0.4
 
 permissions:
   contents: write
@@ -18,3 +21,6 @@ jobs:
           token: ${{ secrets.PAT_GITHUB }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Without this the action reads the config and manifest from the
+          # repository's default branch and would cut a 0.5.0-beta instead.
+          target-branch: release-v0.4

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   },
   "homepage": "https://github.com/rive-app/rive-nitro-react-native#readme",
   "runtimeVersions": {
-    "ios": "6.21.1",
-    "android": "11.7.2"
+    "ios": "6.23.1",
+    "android": "11.9.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Ports the runtime bump from #367 to the stable 0.4.x line: rive-android 11.7.2 → 11.9.1 and rive-ios 6.21.1 → 6.23.1.

Only `package.json` needs changing here. The other two files in #367 (`android/src/new/...` and `ios/new/RiveRuntimeLogger.swift`) arrived with the breaking `feat!: experimental Rive runtime backend` (#134) that started the 0.5.0-beta line, so they don't exist on this branch.

Also points this branch's copy of the release-please workflow at `release-v0.4`. Without `target-branch` the action reads its config and manifest from the repository's default branch and would cut a 0.5.0-beta; a push only ever triggers the workflow file on the branch pushed, so `main` keeps producing betas unchanged. The branch was cut from `v0.4.19`, which already carries a non-prerelease release-please config and a manifest at `0.4.19`, so no config changes were needed. Merging this should produce a `0.4.20` release PR, and a non-prerelease GitHub release publishes to the npm `latest` tag via the existing conditional in `publish.yml`.

On verification, I could not get a green local run on this branch — but nothing I found is attributable to the bump, and each failure reproduces identically at the old pins:

1. The iOS example does not build on Xcode 26.5: RN 0.79's bundled fmt 11.0.2 hits the `consteval` error in `Pods/fmt/include/fmt/format-inl.h`. `main` carries a Podfile fix for this that this branch predates. Confirmed pre-existing by a clean `pod install` + build with RiveRuntime pinned back to 6.21.1 — identical errors.
2. `viewmodel-properties › non-existent properties return undefined` fails. Confirmed pre-existing at rive-android 11.7.2 — identical failure.
3. The Android emulator dies mid-run (`bad color buffer handle`, a gfxstream host-GPU crash), taking ~10 suites down with `adb` errors rather than assertion failures. Reproduced at 11.7.2 as well, on a cold-booted emulator.

What did verify cleanly: Android compiles against 11.9.1 with zero deprecation warnings (this tree predates the API surface 11.9.x deprecates), and `pod install` resolves RiveRuntime 6.23.1. CI is the meaningful gate here, since it runs a different Xcode and emulator image.