### PR TITLE
fix(android): start the configured state machine when deferring autoplay

### DIFF
--- a/android/src/legacy/java/com/rive/RiveReactNativeView.kt
+++ b/android/src/legacy/java/com/rive/RiveReactNativeView.kt
@@ -149,7 +149,18 @@ class RiveReactNativeView(context: ThemedReactContext) : FrameLayout(context) {
         // Create the state machine without advancing Entry transitions.
         // The first Choreographer frame will advance it with the user's
         // VM instance already bound via applyDataBinding() below.
-        riveAnimationView?.play(settleInitialState = false)
+        //
+        // Start the configured state machine explicitly: on a cold start the
+        // no-arg play() also starts the artboard's first raw timeline
+        // animation (same class of bug as #332), which plays on top of the
+        // data-bound state machine and shows the wrong state.
+        val smName = config.stateMachineName
+          ?: riveAnimationView?.controller?.activeArtboard?.stateMachineNames?.firstOrNull()
+        if (smName != null) {
+          riveAnimationView?.play(smName, isStateMachine = true, settleInitialState = false)
+        } else {
+          riveAnimationView?.play(settleInitialState = false)
+        }
       }
       _activeStateMachineName = getSafeStateMachineName()
       configuredStateMachineName = config.stateMachineName


### PR DESCRIPTION
The `deferAutoPlay` branch in `configure()` calls the no-arg `play(settleInitialState = false)`. On a cold start the controller's no-arg `play()` also starts the artboard's **first raw timeline animation**, which draws over the data-bound state machine and shows the wrong state — e.g. a file whose first timeline is a "fail" animation shows the failure art on every mount on Android, regardless of the bound VM values. iOS is unaffected.

Same bug class as #332, which #343 fixed for the public `play()` — this applies the same explicit state-machine start to the internal call site. Repro: any `<RiveView dataBind={...} />` (default `autoPlay`) on Android whose artboard's first linear animation visibly differs from the initial state-machine state.

Co-Authored-By: Claude <noreply@anthropic.com>